### PR TITLE
Introduce a new type as `ReferenceAction` for relation config

### DIFF
--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -73,16 +73,23 @@ public annotation AutoIncrementConfig AutoIncrement on record field;
 #
 # + keyColumns - The foreign key column
 # + reference - The primary key of the other table
-# + cascadeDelete - If it is true, the corresponding records in the other table
-#                   will be deleted when deleting a record from one table
-# + cascadeUpdate - If it is true, the corresponding records in the other table
-#                   will be updated when updating a record from one table
+# + onDelete - The action which will be taken when the referenced value in the parent table is deleted
+# + onUpdate - The action which will be taken when the referenced value in the parent table is updated
 public type RelationConfig record {|
     string[] keyColumns?;
     string[] reference?;
-    boolean cascadeDelete = false;
-    boolean cascadeUpdate = true;
+    ReferenceAction onDelete?;
+    ReferenceAction onUpdate?;
 |};
+
+# Defines actions that can be taken when deleting or updating the parent table’s values.
+public enum ReferenceAction {
+    RESTRICT,
+    CASCADE,
+    SET_NULL,
+    NO_ACTION,
+    SET_DEFAULT
+}
 
 # The annotation is used to indicate the associations of an entity.
 public annotation RelationConfig Relation on field;

--- a/compiler-plugin-test/src/test/java/io/ballerina/stdlib/persist/compiler/script/CompilerPluginTest.java
+++ b/compiler-plugin-test/src/test/java/io/ballerina/stdlib/persist/compiler/script/CompilerPluginTest.java
@@ -71,7 +71,8 @@ public class CompilerPluginTest {
                 "\turgency VARCHAR(191),\n" +
                 "\tquantity INT NOT NULL,\n" +
                 "\titemId INT,\n" +
-                "\tCONSTRAINT FK_MEDICAL_NEED_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICAL_NEED_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) " +
+                "ON DELETE RESTRICT ON UPDATE RESTRICT,\n" +
                 "\tPRIMARY KEY(needId),\n" +
                 "\tUNIQUE KEY(needId)\n" +
                 ")\tAUTO_INCREMENT = 12;";
@@ -110,8 +111,8 @@ public class CompilerPluginTest {
                 "\turgency VARCHAR(191),\n" +
                 "\tquantity INT NOT NULL,\n" +
                 "\titemId INT,\n" +
-                "\tCONSTRAINT FK_MEDICAL_NEED_MEDICINE_0 FOREIGN KEY(itemId) REFERENCES Medicine(id) ON " +
-                "DELETE CASCADE\n" +
+                "\tCONSTRAINT FK_MEDICAL_NEED_MEDICINE_0 FOREIGN KEY(itemId) REFERENCES Medicine(id) " +
+                "ON DELETE CASCADE\n" +
                 ");";
         testSqlScript("package_03", fileContent, 0, "");
     }
@@ -135,7 +136,7 @@ public class CompilerPluginTest {
                 "\tquantity INT NOT NULL,\n" +
                 "\titemId INT,\n" +
                 "\tCONSTRAINT FK_MEDICAL_NEED2_MEDICINE2_0 FOREIGN KEY(itemId) REFERENCES Medicine2(id) " +
-                "ON DELETE CASCADE ON UPDATE CASCADE,\n" +
+                "ON DELETE SET NULL ON UPDATE SET NULL,\n" +
                 "\tPRIMARY KEY(needId)\n" +
                 ")\tAUTO_INCREMENT = 12;";
         testSqlScript("package_04", fileContent, 0, "");
@@ -159,7 +160,7 @@ public class CompilerPluginTest {
                 "\turgency VARCHAR(191) NOT NULL,\n" +
                 "\tquantity INT NOT NULL,\n" +
                 "\titemId INT,\n" +
-                "\tCONSTRAINT FK_EMPLOYEE_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_EMPLOYEE_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE NO ACTION,\n" +
                 "\tPRIMARY KEY(needId),\n" +
                 "\tUNIQUE KEY(beneficiaryId)\n" +
                 ");";
@@ -185,9 +186,9 @@ public class CompilerPluginTest {
                 "\tid INT NOT NULL AUTO_INCREMENT,\n" +
                 "\tname VARCHAR(191) NOT NULL,\n" +
                 "\titemId INT,\n" +
-                "\tCONSTRAINT FK_ITEM1_ITEM2_0 FOREIGN KEY(itemId) REFERENCES Item2(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_ITEM1_ITEM2_0 FOREIGN KEY(itemId) REFERENCES Item2(id) ON DELETE SET DEFAULT,\n" +
                 "\titemName VARCHAR(191),\n" +
-                "\tCONSTRAINT FK_ITEM1_ITEM2_1 FOREIGN KEY(itemName) REFERENCES Item2(name) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_ITEM1_ITEM2_1 FOREIGN KEY(itemName) REFERENCES Item2(name) ON DELETE SET DEFAULT,\n" +
                 "\tPRIMARY KEY(id),\n" +
                 "\tUNIQUE KEY(name)\n" +
                 ")\tAUTO_INCREMENT = 5;\n" +
@@ -208,13 +209,15 @@ public class CompilerPluginTest {
                 "\turgency VARCHAR(191) NOT NULL,\n" +
                 "\tquantity INT NOT NULL,\n" +
                 "\titemId INT,\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE SET DEFAULT,\n" +
                 "\tname VARCHAR(191),\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_1 FOREIGN KEY(name) REFERENCES Item(name) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_1 FOREIGN KEY(name) REFERENCES Item(name) ON DELETE SET DEFAULT,\n" +
                 "\titemId1 INT,\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) " +
+                "ON DELETE SET DEFAULT,\n" +
                 "\tname1 VARCHAR(191),\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM1_1 FOREIGN KEY(name1) REFERENCES Item1(name) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM1_1 FOREIGN KEY(name1) REFERENCES Item1(name) " +
+                "ON DELETE SET DEFAULT,\n" +
                 "\tPRIMARY KEY(needId),\n" +
                 "\tUNIQUE KEY(beneficiaryId, urgency)\n" +
                 ");";
@@ -247,9 +250,10 @@ public class CompilerPluginTest {
                 "\turgency VARCHAR(191) NOT NULL,\n" +
                 "\tquantity INT NOT NULL,\n" +
                 "\titemId INT,\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE SET DEFAULT,\n" +
                 "\titemId1 INT,\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) ON DELETE " +
+                "NO ACTION,\n" +
                 "\tPRIMARY KEY(needId),\n" +
                 "\tUNIQUE KEY(beneficiaryId, urgency)\n" +
                 ");";
@@ -272,7 +276,7 @@ public class CompilerPluginTest {
                 "\tid INT NOT NULL AUTO_INCREMENT,\n" +
                 "\tname VARCHAR(191) NOT NULL,\n" +
                 "\titemId1 INT,\n" +
-                "\tCONSTRAINT FK_ITEM_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_ITEM_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) ON DELETE SET DEFAULT,\n" +
                 "\tPRIMARY KEY(id)\n" +
                 ")\tAUTO_INCREMENT = 3;\n" +
                 "\n" +
@@ -283,7 +287,7 @@ public class CompilerPluginTest {
                 "\turgency VARCHAR(191) NOT NULL,\n" +
                 "\tquantity INT NOT NULL,\n" +
                 "\titemId INT,\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE SET DEFAULT,\n" +
                 "\tPRIMARY KEY(needId),\n" +
                 "\tUNIQUE KEY(beneficiaryId, urgency)\n" +
                 ");";
@@ -307,7 +311,7 @@ public class CompilerPluginTest {
                 "\tid INT NOT NULL AUTO_INCREMENT,\n" +
                 "\tname VARCHAR(191) NOT NULL,\n" +
                 "\titemId1 INT,\n" +
-                "\tCONSTRAINT FK_ITEM_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_ITEM_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) ON DELETE SET DEFAULT,\n" +
                 "\tPRIMARY KEY(id)\n" +
                 ")\tAUTO_INCREMENT = 3;\n" +
                 "\n" +
@@ -318,7 +322,7 @@ public class CompilerPluginTest {
                 "\turgency VARCHAR(191) NOT NULL,\n" +
                 "\tquantity INT NOT NULL,\n" +
                 "\titemId INT,\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE SET DEFAULT,\n" +
                 "\tPRIMARY KEY(needId),\n" +
                 "\tUNIQUE KEY(beneficiaryId, urgency)\n" +
                 ");";
@@ -353,7 +357,7 @@ public class CompilerPluginTest {
                 "\tid INT NOT NULL AUTO_INCREMENT,\n" +
                 "\tname VARCHAR(191) NOT NULL,\n" +
                 "\titemId1 INT,\n" +
-                "\tCONSTRAINT FK_ITEM_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_ITEM_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) ON DELETE SET DEFAULT,\n" +
                 "\tPRIMARY KEY(id)\n" +
                 ")\tAUTO_INCREMENT = 3;\n" +
                 "\n" +
@@ -364,7 +368,7 @@ public class CompilerPluginTest {
                 "\turgency VARCHAR(191) NOT NULL,\n" +
                 "\tquantity INT NOT NULL,\n" +
                 "\titemId INT,\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE SET DEFAULT,\n" +
                 "\tPRIMARY KEY(needId),\n" +
                 "\tUNIQUE KEY(beneficiaryId, urgency)\n" +
                 ");";
@@ -383,7 +387,7 @@ public class CompilerPluginTest {
                 "\tid INT NOT NULL AUTO_INCREMENT,\n" +
                 "\tname VARCHAR(191) NOT NULL,\n" +
                 "\titemId1 INT,\n" +
-                "\tCONSTRAINT FK_ITEM_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_ITEM_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) ON DELETE SET DEFAULT,\n" +
                 "\tPRIMARY KEY(id)\n" +
                 ")\tAUTO_INCREMENT = 3;\n" +
                 "\n" +
@@ -394,7 +398,7 @@ public class CompilerPluginTest {
                 "\turgency VARCHAR(191) NOT NULL,\n" +
                 "\tquantity INT NOT NULL,\n" +
                 "\titemId INT,\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE SET DEFAULT,\n" +
                 "\tPRIMARY KEY(needId),\n" +
                 "\tUNIQUE KEY(beneficiaryId, urgency)\n" +
                 ");\n" +
@@ -441,9 +445,9 @@ public class CompilerPluginTest {
                 "\tid INT NOT NULL AUTO_INCREMENT,\n" +
                 "\tname VARCHAR(20) NOT NULL,\n" +
                 "\titemId INT,\n" +
-                "\tCONSTRAINT FK_ITEM1_ITEM2_0 FOREIGN KEY(itemId) REFERENCES Item2(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_ITEM1_ITEM2_0 FOREIGN KEY(itemId) REFERENCES Item2(id) ON DELETE SET DEFAULT,\n" +
                 "\titemName VARCHAR(20),\n" +
-                "\tCONSTRAINT FK_ITEM1_ITEM2_1 FOREIGN KEY(itemName) REFERENCES Item2(name) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_ITEM1_ITEM2_1 FOREIGN KEY(itemName) REFERENCES Item2(name) ON DELETE SET DEFAULT,\n" +
                 "\tPRIMARY KEY(id),\n" +
                 "\tUNIQUE KEY(name)\n" +
                 ")\tAUTO_INCREMENT = 5;\n" +
@@ -464,13 +468,15 @@ public class CompilerPluginTest {
                 "\turgency VARCHAR(191) NOT NULL,\n" +
                 "\tquantity INT NOT NULL,\n" +
                 "\titemId INT,\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_0 FOREIGN KEY(itemId) REFERENCES Item(id) ON DELETE SET DEFAULT,\n" +
                 "\tname VARCHAR(10),\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_1 FOREIGN KEY(name) REFERENCES Item(name) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM_1 FOREIGN KEY(name) REFERENCES Item(name) ON DELETE SET DEFAULT,\n" +
                 "\titemId1 INT,\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM1_0 FOREIGN KEY(itemId1) REFERENCES Item1(id) " +
+                "ON DELETE SET DEFAULT,\n" +
                 "\tname1 VARCHAR(20),\n" +
-                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM1_1 FOREIGN KEY(name1) REFERENCES Item1(name) ON DELETE CASCADE,\n" +
+                "\tCONSTRAINT FK_MEDICALNEEDS_ITEM1_1 FOREIGN KEY(name1) REFERENCES Item1(name) " +
+                "ON DELETE SET DEFAULT,\n" +
                 "\tPRIMARY KEY(needId),\n" +
                 "\tUNIQUE KEY(beneficiaryId, urgency)\n" +
                 ");";

--- a/compiler-plugin-test/src/test/resources/test-src/plugin/package_01/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/plugin/package_01/sample.bal
@@ -30,7 +30,7 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], onDelete: persist:RESTRICT}
     Item item?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/plugin/package_02/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/plugin/package_02/sample.bal
@@ -30,7 +30,7 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId"], reference: ["id"]}
     Item item?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/plugin/package_03/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/plugin/package_03/sample.bal
@@ -30,7 +30,7 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId"], reference: ["id"]}
     Item item?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/plugin/package_04/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/plugin/package_04/sample.bal
@@ -31,7 +31,7 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], onUpdate: persist:SET_NULL}
     Item item?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/plugin/package_05/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/plugin/package_05/sample.bal
@@ -32,7 +32,7 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId"], reference: ["id"]}
     Item item?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/plugin/package_06/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/plugin/package_06/sample.bal
@@ -30,7 +30,7 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {keyColumns: ["userId", "itemId"], reference: ["id"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["userId", "itemId"], reference: ["id"]}
     Item item?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/plugin/package_07/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/plugin/package_07/sample.bal
@@ -30,7 +30,7 @@ public type MedicalNeed record {|
     time:Civil period?;
     string urgency?;
     int quantity;
-    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId"], reference: ["id"]}
     Item item?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/plugin/package_10/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/plugin/package_10/sample.bal
@@ -30,7 +30,7 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId"], reference: ["id"]}
     Item item?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/sql_script/package_01/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/sql_script/package_01/sample.bal
@@ -29,7 +29,7 @@ public type MedicalNeed record {|
     time:Civil period?;
     string urgency?;
     int quantity;
-    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], onDelete: persist:RESTRICT, onUpdate: persist:RESTRICT}
     Item item?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/sql_script/package_03/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/sql_script/package_03/sample.bal
@@ -23,7 +23,7 @@ public type Medical_Need record {|
     time:Civil period?;
     string urgency?;
     int quantity;
-    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], onDelete: persist:CASCADE}
     Medicine item?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/sql_script/package_04/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/sql_script/package_04/sample.bal
@@ -27,7 +27,7 @@ public type Medical_Need2 record {|
     time:Civil period?;
     string urgency?;
     int quantity;
-    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], cascadeDelete: true, cascadeUpdate: true}
+    @persist:Relation {keyColumns: ["itemId"], reference: ["id"], onDelete: persist:SET_NULL, onUpdate: persist:SET_NULL}
     Medicine2 item?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/sql_script/package_05/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/sql_script/package_05/sample.bal
@@ -29,7 +29,7 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {keyColumns: [], reference: [], cascadeDelete: true}
+    @persist:Relation {keyColumns: [], reference: [], onDelete: persist:NO_ACTION}
     Item item?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/sql_script/package_06/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/sql_script/package_06/sample.bal
@@ -29,9 +29,9 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {keyColumns: ["itemId" , "name"], reference: ["id" , "name"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId" , "name"], reference: ["id" , "name"], onDelete: persist:SET_DEFAULT}
     Item item?;
-    @persist:Relation {keyColumns: ["itemId1" , "name1"], reference: ["id" , "name"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId1" , "name1"], reference: ["id" , "name"], onDelete: persist:SET_DEFAULT}
     Item1 item1?;
 |};
 
@@ -53,7 +53,7 @@ public type Item1 record {
     @persist:AutoIncrement
     readonly int id = 5;
     string name;
-    @persist:Relation {keyColumns: ["itemId" , "itemName"], reference: ["id" , "name"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId" , "itemName"], reference: ["id" , "name"], onDelete: persist:SET_DEFAULT}
     Item2 item?;
 };
 

--- a/compiler-plugin-test/src/test/resources/test-src/sql_script/package_07/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/sql_script/package_07/sample.bal
@@ -29,9 +29,9 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {reference: ["id"], cascadeDelete: true}
+    @persist:Relation {reference: ["id"], onDelete: persist:SET_DEFAULT}
     Item item?;
-    @persist:Relation {keyColumns: ["itemId1"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId1"], onDelete: persist:NO_ACTION}
     Item1 item1?;
 |};
 

--- a/compiler-plugin-test/src/test/resources/test-src/sql_script/package_08/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/sql_script/package_08/sample.bal
@@ -29,7 +29,7 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {reference: ["id"], cascadeDelete: true}
+    @persist:Relation {reference: ["id"], onDelete: persist:SET_DEFAULT}
     Item item?;
 |};
 
@@ -45,6 +45,6 @@ public type Item record {
     @persist:AutoIncrement
     readonly int id = 3;
     string name;
-    @persist:Relation {keyColumns: ["itemId1"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId1"], onDelete: persist:SET_DEFAULT}
     Item1 item1?;
 };

--- a/compiler-plugin-test/src/test/resources/test-src/sql_script/package_09/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/sql_script/package_09/sample.bal
@@ -29,7 +29,7 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {reference: ["id"], cascadeDelete: true}
+    @persist:Relation {reference: ["id"], onDelete: persist:SET_DEFAULT}
     Item item?;
 |};
 
@@ -38,7 +38,7 @@ public type Item record {
     @persist:AutoIncrement
     readonly int id = 3;
     string name;
-    @persist:Relation {keyColumns: ["itemId1"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId1"], onDelete: persist:SET_DEFAULT}
     Item1 item1?;
 };
 

--- a/compiler-plugin-test/src/test/resources/test-src/sql_script/package_10/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/sql_script/package_10/sample.bal
@@ -29,7 +29,7 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {reference: ["id"], cascadeDelete: true}
+    @persist:Relation {reference: ["id"], onDelete: persist:SET_DEFAULT}
     Item item?;
 |};
 
@@ -38,7 +38,7 @@ public type Item record {
     @persist:AutoIncrement
     readonly int id = 3;
     string name;
-    @persist:Relation {keyColumns: ["itemId1"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId1"], onDelete: persist:SET_DEFAULT}
     Item1 item1?;
 };
 

--- a/compiler-plugin-test/src/test/resources/test-src/sql_script/package_11/sample.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/sql_script/package_11/sample.bal
@@ -30,9 +30,9 @@ public type MedicalNeed record {|
     time:Civil period;
     string urgency;
     int quantity;
-    @persist:Relation {keyColumns: ["itemId" , "name"], reference: ["id" , "name"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId" , "name"], reference: ["id" , "name"], onDelete: persist:SET_DEFAULT}
     Item item?;
-    @persist:Relation {keyColumns: ["itemId1" , "name1"], reference: ["id" , "name"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId1" , "name1"], reference: ["id" , "name"], onDelete: persist:SET_DEFAULT}
     Item1 item1?;
 |};
 
@@ -60,7 +60,7 @@ public type Item1 record {
         maxLength: 20
     }
     string name;
-    @persist:Relation {keyColumns: ["itemId" , "itemName"], reference: ["id" , "name"], cascadeDelete: true}
+    @persist:Relation {keyColumns: ["itemId" , "itemName"], reference: ["id" , "name"], onDelete: persist:SET_DEFAULT}
     Item2 item?;
 };
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/Constants.java
@@ -35,9 +35,6 @@ public class Constants {
     public static final String REFERENCE = "reference";
     public static final String START_VALUE = "startValue";
     public static final String ONE = "1";
-    public static final String CASCADE_DELETE = "cascadeDelete";
-    public static final String ON_DELETE_CASCADE = " ON DELETE CASCADE";
-    public static final String ON_UPDATE_CASCADE = " ON UPDATE CASCADE";
     public static final String NOT_NULL = " NOT NULL";
     public static final String AUTO_INCREMENT_WITH_SPACE = " AUTO_INCREMENT";
     public static final String AUTO_INCREMENT_WITH_TAB = "\tAUTO_INCREMENT";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/PersistGenerateSqlScript.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/PersistGenerateSqlScript.java
@@ -62,6 +62,18 @@ public class PersistGenerateSqlScript {
     private static final String EMPTY = "";
     private static final String PRIMARY_KEY_START_SCRIPT = NEW_LINE + TAB + "PRIMARY KEY(";
     private static final String UNIQUE_KEY_START_SCRIPT = NEW_LINE + TAB + "UNIQUE KEY(";
+    public static final String ON_DELETE = "onDelete";
+    public static final String ON_DELETE_SYNTAX = " ON DELETE";
+    public static final String ON_UPDATE_SYNTAX = " ON UPDATE";
+    public static final String RESTRICT = "persist:RESTRICT";
+    public static final String CASCADE = "persist:CASCADE";
+    public static final String SET_NULL = "persist:SET_NULL";
+    public static final String NO_ACTION = "persist:NO_ACTION";
+    public static final String RESTRICT_SYNTAX = " RESTRICT";
+    public static final String CASCADE_SYNTAX = " CASCADE";
+    public static final String NO_ACTION_SYNTAX = " NO ACTION";
+    public static final String SET_NULL_SYNTAX = " SET NULL";
+    public static final String SET_DEFAULT_SYNTAX = " SET DEFAULT";
 
     protected static void generateSqlScript(RecordTypeDescriptorNode recordNode, TypeDefinitionNode typeDefinitionNode,
                                             String tableName, NodeList<ModuleMemberDeclarationNode> memberNodes,
@@ -293,15 +305,15 @@ public class PersistGenerateSqlScript {
                     if (node.isPresent()) {
                         reference = (ListConstructorExpressionNode) node.get();
                     }
-                } else if (specificFieldNode.fieldName().toSourceCode().trim().equals(Constants.CASCADE_DELETE)) {
+                } else if (specificFieldNode.fieldName().toSourceCode().trim().equals(ON_DELETE)) {
                     Optional<ExpressionNode> optional = specificFieldNode.valueExpr();
-                    if (optional.isPresent() && optional.get().toSourceCode().trim().equals(Constants.TRUE)) {
-                        delete = Constants.ON_DELETE_CASCADE;
+                    if (optional.isPresent()) {
+                        delete = ON_DELETE_SYNTAX + getReferenceAction(optional.get().toSourceCode().trim());
                     }
                 } else {
                     Optional<ExpressionNode> optional = specificFieldNode.valueExpr();
-                    if (optional.isPresent() && optional.get().toSourceCode().trim().equals(Constants.TRUE)) {
-                        update = Constants.ON_UPDATE_CASCADE;
+                    if (optional.isPresent()) {
+                        update = ON_UPDATE_SYNTAX + getReferenceAction(optional.get().toSourceCode().trim());
                     }
                 }
             }
@@ -354,6 +366,21 @@ public class PersistGenerateSqlScript {
             }
         }
         return relationScript.toString();
+    }
+
+    private static String getReferenceAction(String value) {
+        switch (value) {
+            case RESTRICT:
+                return RESTRICT_SYNTAX;
+            case CASCADE:
+                return CASCADE_SYNTAX;
+            case NO_ACTION:
+                return NO_ACTION_SYNTAX;
+            case SET_NULL:
+                return SET_NULL_SYNTAX;
+            default:
+                return SET_DEFAULT_SYNTAX;
+        }
     }
 
     private static String constructForeignKeyScript(String fieldName, String fieldType, String tableName,


### PR DESCRIPTION
## Purpose
This PR has introduced a new type with the following action for relation config.
- RESTRICT
- CASCADE
- SET NULL
- NO ACTION
- SET DEFAULT

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/3443

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests