### PR TITLE
Add validations for relations

### DIFF
--- a/compiler-plugin-test/src/test/java/io/ballerina/stdlib/persist/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-test/src/test/java/io/ballerina/stdlib/persist/compiler/CompilerPluginTest.java
@@ -48,6 +48,7 @@ import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_115;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_121;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_122;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_123;
+import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_124;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_129;
 
 /**
@@ -262,6 +263,32 @@ public class CompilerPluginTest {
                 new String[]{
                         "(9:4,9:28)",
                         "(31:4,31:24)"
+                }
+        );
+    }
+
+    @Test
+    public void validatePresenceOfForeignKeyField() {
+        List<Diagnostic> diagnostics = getDiagnostic("foreign-key-present.bal", 4, DiagnosticSeverity.ERROR);
+        testDiagnostic(
+                diagnostics,
+                new String[]{
+                        "entity should not contain foreign key field for relation 'Building'",
+                        "entity should not contain foreign key field for relation 'Building2'",
+                        "entity should not contain foreign key field for relation 'Workspace3'",
+                        "entity should not contain foreign key field for relation 'Building4'"
+                },
+                new String[]{
+                        PERSIST_124.getCode(),
+                        PERSIST_124.getCode(),
+                        PERSIST_124.getCode(),
+                        PERSIST_124.getCode()
+                },
+                new String[]{
+                        "(15:4,15:32)",
+                        "(22:4,22:33)",
+                        "(42:4,42:33)",
+                        "(56:4,56:33)"
                 }
         );
     }

--- a/compiler-plugin-test/src/test/java/io/ballerina/stdlib/persist/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-test/src/test/java/io/ballerina/stdlib/persist/compiler/CompilerPluginTest.java
@@ -47,6 +47,7 @@ import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_114;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_115;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_121;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_122;
+import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_123;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_129;
 
 /**
@@ -241,6 +242,26 @@ public class CompilerPluginTest {
                 new String[]{
                         "(8:4,8:27)",
                         "(27:4,27:23)"
+                }
+        );
+    }
+
+    @Test
+    public void validateDuplicatedRelationField() {
+        List<Diagnostic> diagnostics = getDiagnostic("duplicated-relations-field.bal", 2, DiagnosticSeverity.ERROR);
+        testDiagnostic(
+                diagnostics,
+                new String[]{
+                        "entity does not support duplicated relations to an associated entity",
+                        "entity does not support duplicated relations to an associated entity"
+                },
+                new String[]{
+                        PERSIST_123.getCode(),
+                        PERSIST_123.getCode()
+                },
+                new String[]{
+                        "(9:4,9:28)",
+                        "(31:4,31:24)"
                 }
         );
     }

--- a/compiler-plugin-test/src/test/resources/test-src/project_2/persist/duplicated-relations-field.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/project_2/persist/duplicated-relations-field.bal
@@ -1,0 +1,33 @@
+import ballerina/persist as _;
+
+type Building record {|
+    readonly string buildingCode;
+    string city;
+    string state;
+    string country;
+    string postalCode;
+    Workspace[] workspaces1;
+    Workspace[] workspaces2;
+|};
+
+type Workspace record {|
+    readonly string workspaceId;
+    string workspaceType;
+    Building building;
+|};
+
+type Building1 record {|
+    readonly string buildingCode;
+    string city;
+    string state;
+    string country;
+    string postalCode;
+    Workspace2[] workspaces;
+|};
+
+type Workspace2 record {|
+    readonly string workspaceId;
+    string workspaceType;
+    Building1 location1;
+    Building1 location2;
+|};

--- a/compiler-plugin-test/src/test/resources/test-src/project_2/persist/foreign-key-present.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/project_2/persist/foreign-key-present.bal
@@ -1,0 +1,69 @@
+import ballerina/persist as _;
+
+type Building record {|
+    readonly string buildingCode;
+    string city;
+    string state;
+    string country;
+    string postalCode;
+    string workspaceWorkspaceId;
+    Workspace[] workspaces;
+|};
+
+type Workspace record {|
+    readonly string workspaceId;
+    string workspaceType;
+    string buildingBuildingCode;
+    Building building;
+|};
+
+type Workspace2 record {|
+    readonly string workspaceId;
+    string workspaceType;
+    string building2BuildingCode;
+    Building2 location;
+|};
+
+type Building2 record {|
+    readonly string buildingCode;
+    string city;
+    string state;
+    string country;
+    string postalCode;
+    string workspace2WorkspaceId;
+    Workspace2[] workspaces;
+|};
+
+type Building3 record {|
+    readonly string buildingCode;
+    string city;
+    string state;
+    string country;
+    string postalCode;
+    string workspace3WorkspaceId;
+    Workspace3 workspaces;
+|};
+
+type Workspace3 record {|
+    readonly string workspaceId;
+    string workspaceType;
+    string building3BuildingCode;
+    Building3 building;
+|};
+
+type Workspace4 record {|
+    readonly string workspaceId;
+    string workspaceType;
+    string building4BuildingCode;
+    Building4 location;
+|};
+
+type Building4 record {|
+    readonly string buildingCode;
+    string city;
+    string state;
+    string country;
+    string postalCode;
+    string workspace4WorkspaceId;
+    Workspace4 workspaces;
+|};

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/Constants.java
@@ -33,14 +33,15 @@ public final class Constants {
      */
     public static final class BallerinaTypes {
 
-        private BallerinaTypes() {}
-
         public static final String INT = "int";
         public static final String STRING = "string";
         public static final String BOOLEAN = "boolean";
         public static final String DECIMAL = "decimal";
         public static final String FLOAT = "float";
         public static final String BYTE = "byte";
+
+        private BallerinaTypes() {
+        }
     }
 
     /**
@@ -48,12 +49,13 @@ public final class Constants {
      */
     public static final class BallerinaTimeTypes {
 
-        private BallerinaTimeTypes() {}
-
         public static final String DATE = "Date";
         public static final String TIME_OF_DAY = "TimeOfDay";
         public static final String UTC = "Utc";
         public static final String CIVIL = "Civil";
+
+        private BallerinaTimeTypes() {
+        }
     }
 
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/DiagnosticsCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/DiagnosticsCodes.java
@@ -40,6 +40,7 @@ public enum DiagnosticsCodes {
     PERSIST_121("PERSIST_121", "an entity cannot reference itself in association", ERROR),
     PERSIST_122("PERSIST_122",
             "the associated entity ''{0}'' does not have the field with the relationship type", ERROR),
+    PERSIST_123("PERSIST_123", "entity does not support duplicated relations to an associated entity", ERROR),
     PERSIST_129("PERSIST_129", "n:m association is not supported yet", ERROR);
 
     private final String code;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/DiagnosticsCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/DiagnosticsCodes.java
@@ -41,6 +41,7 @@ public enum DiagnosticsCodes {
     PERSIST_122("PERSIST_122",
             "the associated entity ''{0}'' does not have the field with the relationship type", ERROR),
     PERSIST_123("PERSIST_123", "entity does not support duplicated relations to an associated entity", ERROR),
+    PERSIST_124("PERSIST_124", "entity should not contain foreign key field for relation ''{0}''", ERROR),
     PERSIST_129("PERSIST_129", "n:m association is not supported yet", ERROR);
 
     private final String code;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/PersistModelDefinitionValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/PersistModelDefinitionValidator.java
@@ -74,6 +74,7 @@ import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_114;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_115;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_121;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_122;
+import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_123;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_129;
 
 /**
@@ -286,6 +287,7 @@ public class PersistModelDefinitionValidator implements AnalysisTask<SyntaxNodeA
             return;
         }
 
+        List<String> validRelationTypes = new ArrayList<>();
         for (RelationField relationField : entity.getRelationFields()) {
             String referredEntity = relationField.getType();
 
@@ -294,6 +296,15 @@ public class PersistModelDefinitionValidator implements AnalysisTask<SyntaxNodeA
                         PERSIST_121.getSeverity(), relationField.getLocation());
                 break;
             }
+
+            // Duplicated Relations
+            if (validRelationTypes.contains(relationField.getType())) {
+                entity.reportDiagnostic(PERSIST_123.getCode(), PERSIST_123.getMessage(),
+                        PERSIST_123.getSeverity(), relationField.getLocation());
+                break;
+            }
+
+            validRelationTypes.add(relationField.getType());
 
             if (this.entities.containsKey(referredEntity)) {
                 validateRelation(relationField, this.entities.get(referredEntity), entity);

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/model/Entity.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/model/Entity.java
@@ -26,7 +26,9 @@ import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Model class to hold entity properties.
@@ -34,9 +36,11 @@ import java.util.List;
 public class Entity {
     private final String entityName;
     private final NodeLocation entityNameLocation;
-    private int readonlyFieldCount = 0;
     private final RecordTypeDescriptorNode typeDescriptorNode;
 
+    private int readonlyFieldCount = 0;
+    private final List<String> identifierFields = new ArrayList<>();
+    private final Map<String, NodeLocation> nonRelationFields = new HashMap<>();
     private boolean containsRelations = false;
     private final List<RelationField> relationFields = new ArrayList<>();
 
@@ -66,6 +70,22 @@ public class Entity {
 
     public void incrementReadonlyFieldCount() {
         this.readonlyFieldCount++;
+    }
+
+    public List<String> getIdentifierFields() {
+        return identifierFields;
+    }
+
+    public void addIdentifierField(String fieldName) {
+        this.identifierFields.add(fieldName);
+    }
+
+    public Map<String, NodeLocation> getNonRelationFields() {
+        return nonRelationFields;
+    }
+
+    public void addNonRelationField(String fieldName, NodeLocation location) {
+        this.nonRelationFields.put(fieldName, location);
     }
 
     public boolean isContainsRelations() {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/model/Entity.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/model/Entity.java
@@ -37,14 +37,12 @@ public class Entity {
     private final String entityName;
     private final NodeLocation entityNameLocation;
     private final RecordTypeDescriptorNode typeDescriptorNode;
-
-    private int readonlyFieldCount = 0;
     private final List<String> identifierFields = new ArrayList<>();
     private final Map<String, NodeLocation> nonRelationFields = new HashMap<>();
-    private boolean containsRelations = false;
     private final List<RelationField> relationFields = new ArrayList<>();
-
     private final List<Diagnostic> diagnosticList = new ArrayList<>();
+    private int readonlyFieldCount = 0;
+    private boolean containsRelations = false;
 
     public Entity(String entityName, NodeLocation entityNameLocation, RecordTypeDescriptorNode typeDescriptorNode) {
         this.entityName = entityName;


### PR DESCRIPTION
## Purpose
1. Foreign key field inferred should not be present in the owner entity definition
2. Duplicate relations is not allowed 

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/3926

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests