### PR TITLE
Make entity and field names case-insensitive

### DIFF
--- a/compiler-plugin-test/src/test/java/io/ballerina/stdlib/persist/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-test/src/test/java/io/ballerina/stdlib/persist/compiler/CompilerPluginTest.java
@@ -39,12 +39,14 @@ import java.util.stream.Collectors;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_101;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_102;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_103;
+import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_105;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_201;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_202;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_203;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_204;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_205;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_206;
+import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_207;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_301;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_302;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_303;
@@ -381,6 +383,26 @@ public class CompilerPluginTest {
                 },
                 new String[]{
                         "(18:4,18:33)"
+                }
+        );
+    }
+
+    @Test
+    public void validateEntityNamesCaseSensitivity() {
+        List<Diagnostic> diagnostics = getErrorDiagnostics("case-sensitive-entities.bal", 2);
+        testDiagnostic(
+                diagnostics,
+                new String[]{
+                        PERSIST_105.getCode(),
+                        PERSIST_207.getCode()
+                },
+                new String[]{
+                        "redeclared entity 'building'",
+                        "redeclared field 'Location'"
+                },
+                new String[]{
+                        "(12:5,12:13)",
+                        "(27:11,27:19)"
                 }
         );
     }

--- a/compiler-plugin-test/src/test/resources/test-src/project_2/persist/case-sensitive-entities.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/project_2/persist/case-sensitive-entities.bal
@@ -1,0 +1,30 @@
+import ballerina/persist as _;
+
+type Building record {|
+    readonly string 'buildingCode;
+    string city;
+    string state;
+    string country;
+    'string postalCode;
+
+    Workspace[] workspaces;
+|};
+
+type building record {|
+    readonly string 'buildingCode;
+    string city;
+    string state;
+    string country;
+    'string postalCode;
+
+    Workspace[] workspaces;
+|};
+
+type Workspace record {|
+    readonly string workspaceId;
+    string workspaceType;
+
+    Building location;
+    string Location;
+|};
+

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/DiagnosticsCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/DiagnosticsCodes.java
@@ -29,6 +29,7 @@ public enum DiagnosticsCodes {
     PERSIST_101("PERSIST_101", "persist model definition only supports record definitions", ERROR),
     PERSIST_102("PERSIST_102", "an entity should be a closed record", ERROR),
     PERSIST_103("PERSIST_103", "entity ''{0}'' must have at least one identifier readonly field", ERROR),
+    PERSIST_105("PERSIST_105", "redeclared entity ''{0}''", ERROR),
 
     PERSIST_201("PERSIST_201", "an entity does not support rest descriptor field", ERROR),
     PERSIST_202("PERSIST_202", "an entity does not support defaultable field", ERROR),
@@ -36,6 +37,7 @@ public enum DiagnosticsCodes {
     PERSIST_204("PERSIST_204", "an entity does not support optional field", ERROR),
     PERSIST_205("PERSIST_205", "{0}-typed field is not supported in an entity", ERROR),
     PERSIST_206("PERSIST_206", "array of {0}-typed field is not supported in an entity", ERROR),
+    PERSIST_207("PERSIST_207", "redeclared field ''{0}''", ERROR),
 
     PERSIST_301("PERSIST_301", "an entity cannot reference itself in association", ERROR),
     PERSIST_302("PERSIST_302",

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/PersistModelDefinitionValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/PersistModelDefinitionValidator.java
@@ -68,12 +68,14 @@ import static io.ballerina.stdlib.persist.compiler.Constants.TIME_MODULE;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_101;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_102;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_103;
+import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_105;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_201;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_202;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_203;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_204;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_205;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_206;
+import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_207;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_301;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_302;
 import static io.ballerina.stdlib.persist.compiler.DiagnosticsCodes.PERSIST_303;
@@ -103,14 +105,26 @@ public class PersistModelDefinitionValidator implements AnalysisTask<SyntaxNodeA
         }
 
         ModulePartNode rootNode = (ModulePartNode) ctx.node();
+        // Names in lowercase to check for duplicate entity names
+        List<String> entityNames = new ArrayList<>();
         List<TypeDefinitionNode> foundEntities = new ArrayList<>();
         for (ModuleMemberDeclarationNode member : rootNode.members()) {
             if (member instanceof TypeDefinitionNode) {
                 TypeDefinitionNode typeDefinitionNode = (TypeDefinitionNode) member;
                 TypeDescriptorNode typeDescriptorNode = (TypeDescriptorNode) typeDefinitionNode.typeDescriptor();
                 if (typeDescriptorNode instanceof RecordTypeDescriptorNode) {
-                    foundEntities.add(typeDefinitionNode);
-                    this.entityNames.add(stripEscapeCharacter(typeDefinitionNode.typeName().text().trim()));
+                    String entityName = stripEscapeCharacter(typeDefinitionNode.typeName().text().trim());
+                    if (entityNames.contains(entityName.toLowerCase(Locale.ROOT))) {
+                        ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(
+                            new DiagnosticInfo(PERSIST_105.getCode(),
+                                    MessageFormat.format(PERSIST_105.getMessage(), entityName),
+                                    PERSIST_105.getSeverity()), typeDefinitionNode.typeName().location())
+                        );
+                    } else {
+                        foundEntities.add(typeDefinitionNode);
+                        entityNames.add(entityName.toLowerCase(Locale.ROOT));
+                        this.entityNames.add(entityName);
+                    }
                     continue;
                 }
             }
@@ -160,16 +174,19 @@ public class PersistModelDefinitionValidator implements AnalysisTask<SyntaxNodeA
         }
 
         NodeList<Node> fields = typeDescriptorNode.fields();
+        // FieldNames in lower case
+        List<String> fieldNames = new ArrayList<>();
         for (Node fieldNode : fields) {
             IdentifierField identifierField = null;
             boolean isIdentifierField = false;
             RecordFieldNode recordFieldNode;
+            String fieldName;
             if (fieldNode instanceof RecordFieldNode) {
                 recordFieldNode = (RecordFieldNode) fieldNode;
+                fieldName = stripEscapeCharacter(recordFieldNode.fieldName().text().trim());
                 if (recordFieldNode.readonlyKeyword().isPresent()) {
                     isIdentifierField = true;
-                    identifierField = new IdentifierField(
-                            stripEscapeCharacter(recordFieldNode.fieldName().text().trim()));
+                    identifierField = new IdentifierField(fieldName);
                 }
             } else if (fieldNode instanceof RecordFieldWithDefaultValueNode) {
                 entity.reportDiagnostic(PERSIST_202.getCode(), PERSIST_202.getMessage(), PERSIST_202.getSeverity(),
@@ -181,6 +198,14 @@ public class PersistModelDefinitionValidator implements AnalysisTask<SyntaxNodeA
                         fieldNode.location());
                 continue;
             }
+
+            if (fieldNames.contains(fieldName.toLowerCase(Locale.ROOT))) {
+                entity.reportDiagnostic(PERSIST_207.getCode(),
+                        MessageFormat.format(PERSIST_207.getMessage(), fieldName), PERSIST_207.getSeverity(),
+                        recordFieldNode.fieldName().location());
+                continue;
+            }
+            fieldNames.add(fieldName.toLowerCase(Locale.ROOT));
 
             // Check if optional field
             if (recordFieldNode.questionMarkToken().isPresent()) {


### PR DESCRIPTION
## Purpose
$subject

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/4022

## Examples
<img width="500" alt="Screenshot 2023-02-01 at 15 53 47" src="https://user-images.githubusercontent.com/27669465/216017567-25e45ee7-ebb6-400a-8a22-fafb3f4dd036.png">
<img width="500" alt="Screenshot 2023-02-01 at 15 53 55" src="https://user-images.githubusercontent.com/27669465/216017585-18d7defe-6a39-436f-8f1f-97e62073fcc7.png">

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the specification~
- [ ] ~Updated the changelog~
- [x] Added tests