### PR TITLE
Restrict identifier field types to int, float, string, decimal, and boolean

### DIFF
--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -85,7 +85,7 @@ Ballerina record fields are used to model the attributes of an entity. The type 
 
 The entity must contain at least one identifier field. The field's value is used to identify each record uniquely. The identifier field(s) is indicated `readonly` flag.
 
-Say type T is a subtype of SimpleType, and T does not contain (),
+Say type T is one of 'int', 'string', 'float', 'boolean' or 'decimal' types,
 
 ```ballerina
 type EntityType record {|

--- a/changelog.md
+++ b/changelog.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Support for generic persistent client and annotations
-- Support SQL script generation
-- Support for advanced filter queries
+- Support to define Entity Data Model (Explicit entities, 1-1 associations and 1-n associations)
+- Support for generic persistent client
+- Support for validations based on EDM specification
 
 ### Changed

--- a/compiler-plugin-test/src/test/java/io/ballerina/stdlib/persist/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-test/src/test/java/io/ballerina/stdlib/persist/compiler/CompilerPluginTest.java
@@ -207,29 +207,25 @@ public class CompilerPluginTest {
 
     @Test
     public void validateIdentifierFieldProperties() {
-        List<Diagnostic> diagnostics = getErrorDiagnostics("identifier-field-properties.bal", 5);
+        List<Diagnostic> diagnostics = getErrorDiagnostics("identifier-field-properties.bal", 3);
         testDiagnostic(
                 diagnostics,
                 new String[]{
                         PERSIST_502.getCode(),
                         PERSIST_503.getCode(),
-                        PERSIST_421.getCode(),
-                        PERSIST_502.getCode(),
                         PERSIST_503.getCode()
                 },
                 new String[]{
                         "an identifier field cannot be nillable",
-                        "association fields cannot be an identifier field",
-                        "an entity does not support nillable associations",
-                        "an identifier field cannot be nillable",
-                        "association fields cannot be an identifier field"
+                        "only 'int', 'string', 'float', 'boolean', 'decimal' types " +
+                                "are supported as identifier fields, found 'time:Civil'",
+                        "only 'int', 'string', 'float', 'boolean', 'decimal' types " +
+                                "are supported as identifier fields, found 'MedicalNeed'"
                 },
                 new String[]{
                         "(4:13,4:17)",
-                        "(19:13,19:24)",
-                        "(28:13,28:25)",
-                        "(28:13,28:25)",
-                        "(28:13,28:25)"
+                        "(16:13,16:23)",
+                        "(18:13,18:24)"
                 }
         );
     }

--- a/compiler-plugin-test/src/test/resources/test-src/project_2/persist/identifier-field-properties.bal
+++ b/compiler-plugin-test/src/test/resources/test-src/project_2/persist/identifier-field-properties.bal
@@ -8,23 +8,13 @@ public type MedicalNeed record {|
     time:Civil period;
     int quantity;
     MedicalNeed1 mn1;
-    MedicalNeed2 mn2;
 |};
 
 public type MedicalNeed1 record {|
     readonly int needId;
     int itemId;
     int beneficiaryId;
-    time:Civil period;
+    readonly time:Civil period;
     int quantity;
     readonly MedicalNeed mn;
-|};
-
-public type MedicalNeed2 record {|
-    readonly int needId;
-    int itemId;
-    int beneficiaryId;
-    time:Civil period;
-    int quantity;
-    readonly MedicalNeed? mn;
 |};

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/DiagnosticsCodes.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/DiagnosticsCodes.java
@@ -50,7 +50,8 @@ public enum DiagnosticsCodes {
 
     PERSIST_501("PERSIST_501", "''{0}'' entity must have at least one identifier readonly field", ERROR),
     PERSIST_502("PERSIST_502", "an identifier field cannot be nillable", ERROR),
-    PERSIST_503("PERSIST_503", "association fields cannot be an identifier field", ERROR);
+    PERSIST_503("PERSIST_503", "only ''int'', ''string'', ''float'', ''boolean'', ''decimal'' " +
+            "types are supported as identifier fields, found ''{0}''", ERROR);
 
     private final String code;
     private final String message;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/PersistModelDefinitionValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/PersistModelDefinitionValidator.java
@@ -247,17 +247,7 @@ public class PersistModelDefinitionValidator implements AnalysisTask<SyntaxNodeA
             if (processedTypeNode instanceof BuiltinSimpleNameReferenceNode) {
                 String type = ((BuiltinSimpleNameReferenceNode) processedTypeNode).name().text();
                 identifierFieldType = type;
-                if (isValidSimpleType(type)) {
-                    if (isArrayType) {
-                        entity.reportDiagnostic(PERSIST_306.getCode(),
-                                MessageFormat.format(PERSIST_306.getMessage(), type),
-                                PERSIST_306.getSeverity(), processedTypeNode.location());
-                    }
-                } else if (!(type.equals(BYTE) && isArrayType)) {
-                    entity.reportDiagnostic(PERSIST_305.getCode(), MessageFormat.format(PERSIST_305.getMessage(),
-                                    type + typeNamePostfix), PERSIST_305.getSeverity(),
-                            typeNode.location());
-                }
+                validateSimpleTypes(entity, typeNode, processedTypeNode, typeNamePostfix, isArrayType, type);
                 entity.addNonRelationField(stripEscapeCharacter(recordFieldNode.fieldName().text().trim()),
                         recordFieldNode.location());
             } else if (processedTypeNode instanceof QualifiedNameReferenceNode) {
@@ -293,16 +283,8 @@ public class PersistModelDefinitionValidator implements AnalysisTask<SyntaxNodeA
                     entity.addRelationField(new RelationField(typeName, isArrayType, recordFieldNode.location(),
                             entity.getEntityName()));
                 // Revisit once https://github.com/ballerina-platform/ballerina-lang/issues/39441 is resolved
-                } else if (isValidSimpleType(typeName)) {
-                    if (isArrayType) {
-                        entity.reportDiagnostic(PERSIST_306.getCode(),
-                                MessageFormat.format(PERSIST_306.getMessage(), typeName),
-                                PERSIST_306.getSeverity(), processedTypeNode.location());
-                    }
-                } else if (!(typeName.equals(BYTE) && isArrayType)) {
-                    entity.reportDiagnostic(PERSIST_305.getCode(), MessageFormat.format(PERSIST_305.getMessage(),
-                                    typeName + typeNamePostfix), PERSIST_305.getSeverity(),
-                            typeNode.location());
+                } else {
+                    validateSimpleTypes(entity, typeNode, processedTypeNode, typeNamePostfix, isArrayType, typeName);
                 }
             } else {
                 String typeName = Utils.getTypeName(processedTypeNode);
@@ -317,6 +299,21 @@ public class PersistModelDefinitionValidator implements AnalysisTask<SyntaxNodeA
                 identifierField.setTypeLocation(typeNode.location());
                 entity.addIdentifierField(identifierField);
             }
+        }
+    }
+
+    private void validateSimpleTypes(Entity entity, Node typeNode, Node processedTypeNode, String typeNamePostfix,
+                                     boolean isArrayType, String type) {
+        if (isValidSimpleType(type)) {
+            if (isArrayType) {
+                entity.reportDiagnostic(PERSIST_306.getCode(),
+                        MessageFormat.format(PERSIST_306.getMessage(), type),
+                        PERSIST_306.getSeverity(), processedTypeNode.location());
+            }
+        } else if (!(type.equals(BYTE) && isArrayType)) {
+            entity.reportDiagnostic(PERSIST_305.getCode(), MessageFormat.format(PERSIST_305.getMessage(),
+                            type + typeNamePostfix), PERSIST_305.getSeverity(),
+                    typeNode.location());
         }
     }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/model/IdentifierField.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/model/IdentifierField.java
@@ -25,7 +25,7 @@ import io.ballerina.compiler.syntax.tree.NodeLocation;
  */
 public class IdentifierField {
     private final String name;
-    private boolean isSimpleType = false;
+    private String type;
     private boolean isNullable = false;
     private NodeLocation typeLocation;
 
@@ -37,12 +37,12 @@ public class IdentifierField {
         return name;
     }
 
-    public boolean isSimpleType() {
-        return isSimpleType;
+    public String getType() {
+        return type;
     }
 
-    public void setSimpleType(boolean simpleType) {
-        isSimpleType = simpleType;
+    public void setType(String type) {
+        this.type = type;
     }
 
     public boolean isNullable() {

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -112,7 +112,7 @@ Ballerina record fields are used to model the attributes of an entity. The type 
 
 The entity must contain at least one identifier field. The field's value is used to identify each record uniquely. The identifier field(s) is indicated `readonly` flag.
 
-Say type T is a subtype of SimpleType, and T does not contain (),
+Say type T is one of 'int', 'string', 'float', 'boolean' or 'decimal' types,
 
 ```ballerina
 type EntityType record {|


### PR DESCRIPTION
## Purpose
$subject

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/4061

## Checklist
- [x] Linked to an issue
- [x] Updated the specification
- [x] Updated the changelog
- [x] Added tests