### PR TITLE
Fix issue with retrieving many-to-one associations when key fields are not present

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -24,6 +24,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
 
 [[package]]
 org = "ballerina"
@@ -51,6 +54,7 @@ org = "ballerina"
 name = "persist"
 version = "0.2.3"
 dependencies = [
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "sql"},
 	{org = "ballerina", name = "test"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -24,9 +24,6 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
-]
 
 [[package]]
 org = "ballerina"
@@ -54,7 +51,6 @@ org = "ballerina"
 name = "persist"
 version = "0.2.3"
 dependencies = [
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "sql"},
 	{org = "ballerina", name = "test"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -65,7 +65,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/sql_client.bal
+++ b/ballerina/sql_client.bal
@@ -79,7 +79,7 @@ public client class SQLClient {
     # + return - A record in the `rowType` type or a `persist:Error` if the operation fails
     public isolated function runReadByKeyQuery(typedesc<record {}> rowType, typedesc<record {}> rowTypeWithIdFields, anydata key, string[] fields = [], string[] include = [], typedesc<record {}>[] typeDescriptions = []) returns record {}|Error {
         sql:ParameterizedQuery query = sql:queryConcat(
-            `SELECT `, self.getSelectColumnNames(fields, include), ` FROM `, self.tableName, ` AS `, stringToParameterizedQuery(self.entityName)
+            `SELECT `, self.getSelectColumnNames(fields), ` FROM `, self.tableName, ` AS `, stringToParameterizedQuery(self.entityName)
         );
 
         foreach string joinKey in self.joinMetadata.keys() {
@@ -126,7 +126,7 @@ public client class SQLClient {
     public isolated function runReadQuery(typedesc<record {}> rowType, string[] fields = [], string[] include = [])
     returns stream<record {}, sql:Error?>|Error {
         sql:ParameterizedQuery query = sql:queryConcat(
-            `SELECT `, self.getSelectColumnNames(fields, include), ` FROM `, self.tableName, ` `, stringToParameterizedQuery(self.entityName)
+            `SELECT `, self.getSelectColumnNames(fields), ` FROM `, self.tableName, ` `, stringToParameterizedQuery(self.entityName)
         );
 
         string[] joinKeys = self.joinMetadata.keys();
@@ -277,7 +277,7 @@ public client class SQLClient {
         return params;
     }
 
-    private isolated function getSelectColumnNames(string[] fields, string[] include) returns sql:ParameterizedQuery {
+    private isolated function getSelectColumnNames(string[] fields) returns sql:ParameterizedQuery {
         sql:ParameterizedQuery params = ` `;
         int columnCount = 0;
 

--- a/ballerina/tests/associations-tests.bal
+++ b/ballerina/tests/associations-tests.bal
@@ -165,7 +165,6 @@ function departmentRelationsTest() returns error? {
 }
 
 public type WorkspaceInfo record {|
-    readonly string workspaceId;
     string workspaceType;
     Building location;
     Employee[] employees;
@@ -197,7 +196,6 @@ function workspaceRelationsTest() returns error? {
     WorkspaceInfo retrieved = check rainierClient->/workspace/["workspace-22"].get();
 
     WorkspaceInfo expected = {
-        workspaceId: "workspace-22",
         workspaceType: "medium",
         location: {
             buildingCode: "building-22",
@@ -234,9 +232,8 @@ function workspaceRelationsTest() returns error? {
     boolean found = false;
     _ = from WorkspaceInfo workspace in workspaces
         do {
-            if (workspace.workspaceId == "workspace-22") {
+            if workspace == expected {
                 found = true;
-                test:assertEquals(workspace, expected);
             }
         };
 

--- a/ballerina/tests/associations-tests.bal
+++ b/ballerina/tests/associations-tests.bal
@@ -1,7 +1,6 @@
 import ballerina/test;
 
 public type EmployeeInfo record {|
-    readonly string empNo;
     string firstName;
     string lastName;
     record {|
@@ -60,7 +59,6 @@ function employeeRelationsTest() returns error? {
     EmployeeInfo retrieved = check rainierClient->/employee/["employee-21"].get();
     
     EmployeeInfo expected = {
-        empNo: "employee-21",
         firstName: "Tom",
         lastName: "Scott",
         department: {
@@ -79,7 +77,7 @@ function employeeRelationsTest() returns error? {
 }
 
 public type DepartmentInfo record {|
-    readonly string deptNo;
+    string deptNo;
     string deptName;
     record {|
         string firstName;
@@ -247,7 +245,7 @@ function workspaceRelationsTest() returns error? {
 }
 
 public type BuildingInfo record {|
-    readonly string buildingCode;
+    string buildingCode;
     string city;
     string state;
     string country;

--- a/ballerina/tests/id-fields-tests.bal
+++ b/ballerina/tests/id-fields-tests.bal
@@ -412,7 +412,7 @@ public type CompositeAssociationRecordDependent record {|
         string stringType;
         boolean booleanType;
         string randomField;
-    |} alltypesidrecord;
+    |} allTypesIdRecord;
 |};
 
 @test:Config {
@@ -475,7 +475,7 @@ function compositeAssociationsTest() returns error? {
         randomField: compositeAssociationRecord1.randomField, 
         alltypesidrecordIntType: compositeAssociationRecord1.alltypesidrecordIntType, 
         alltypesidrecordDecimalType: compositeAssociationRecord1.alltypesidrecordDecimalType,
-        alltypesidrecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}
+        allTypesIdRecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}
     }, retrievedRecord1Dependent);
 
     // read
@@ -487,8 +487,8 @@ function compositeAssociationsTest() returns error? {
     CompositeAssociationRecordDependent[] compositeAssociationRecordsDependent = check from CompositeAssociationRecordDependent compositeAssociationRecord in testEntitiesClient->/compositeassociationrecord.get(CompositeAssociationRecordDependent)
         select compositeAssociationRecord;
     test:assertEquals(compositeAssociationRecordsDependent, [
-        {randomField: compositeAssociationRecord1.randomField, alltypesidrecordIntType: compositeAssociationRecord1.alltypesidrecordIntType, alltypesidrecordDecimalType: compositeAssociationRecord1.alltypesidrecordDecimalType, alltypesidrecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}}, 
-        {randomField: compositeAssociationRecord2.randomField, alltypesidrecordIntType: compositeAssociationRecord2.alltypesidrecordIntType, alltypesidrecordDecimalType: compositeAssociationRecord2.alltypesidrecordDecimalType, alltypesidrecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}}
+        {randomField: compositeAssociationRecord1.randomField, alltypesidrecordIntType: compositeAssociationRecord1.alltypesidrecordIntType, alltypesidrecordDecimalType: compositeAssociationRecord1.alltypesidrecordDecimalType, allTypesIdRecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}}, 
+        {randomField: compositeAssociationRecord2.randomField, alltypesidrecordIntType: compositeAssociationRecord2.alltypesidrecordIntType, alltypesidrecordDecimalType: compositeAssociationRecord2.alltypesidrecordDecimalType, allTypesIdRecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}}
     ]);
 
     // update

--- a/ballerina/tests/id-fields-tests.bal
+++ b/ballerina/tests/id-fields-tests.bal
@@ -429,7 +429,7 @@ function compositeAssociationsTest() returns error? {
         alltypesidrecordStringType: "id-1",
         alltypesidrecordFloatType: 1.0,
         alltypesidrecordBooleanType: true,
-        alltypesidrecordDecimalType: 1.1d        
+        alltypesidrecordDecimalType: 1.10        
     };
 
     CompositeAssociationRecord compositeAssociationRecord2 = {
@@ -439,7 +439,7 @@ function compositeAssociationsTest() returns error? {
         alltypesidrecordStringType: "id-1",
         alltypesidrecordFloatType: 1.0,
         alltypesidrecordBooleanType: true,
-        alltypesidrecordDecimalType: 1.1d        
+        alltypesidrecordDecimalType: 1.10       
     };
 
     CompositeAssociationRecord compositeAssociationRecordUpdated1 = {
@@ -449,7 +449,7 @@ function compositeAssociationsTest() returns error? {
         alltypesidrecordStringType: "id-1",
         alltypesidrecordFloatType: 1.0,
         alltypesidrecordBooleanType: true,
-        alltypesidrecordDecimalType: 1.1d
+        alltypesidrecordDecimalType: 1.10
     };
 
     AllTypesIdRecordOptionalized allTypesIdRecord1 = {
@@ -457,7 +457,7 @@ function compositeAssociationsTest() returns error? {
         stringType: "id-1",
         floatType: 1.0,
         booleanType: true,
-        decimalType: 1.1d,
+        decimalType: 1.10,
         randomField: "test1Updated"
     };
 
@@ -483,13 +483,13 @@ function compositeAssociationsTest() returns error? {
         select compositeAssociationRecord;
     test:assertEquals(compositeAssociationRecords, [compositeAssociationRecord1, compositeAssociationRecord2]);
 
-    // // read dependent
-    // CompositeAssociationRecordDependent[] compositeAssociationRecordsDependent = check from CompositeAssociationRecordDependent compositeAssociationRecord in testEntitiesClient->/compositeassociationrecord.get(CompositeAssociationRecordDependent)
-    //     select compositeAssociationRecord;
-    // test:assertEquals(compositeAssociationRecordsDependent, [
-    //     {randomField: compositeAssociationRecord1.randomField, alltypesidrecordIntType: compositeAssociationRecord1.alltypesidrecordIntType, alltypesidrecordDecimalType: compositeAssociationRecord1.alltypesidrecordDecimalType, allTypesIdRecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}}, 
-    //     {randomField: compositeAssociationRecord2.randomField, alltypesidrecordIntType: compositeAssociationRecord2.alltypesidrecordIntType, alltypesidrecordDecimalType: compositeAssociationRecord2.alltypesidrecordDecimalType, allTypesIdRecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}}
-    // ]);
+    // read dependent
+    CompositeAssociationRecordDependent[] compositeAssociationRecordsDependent = check from CompositeAssociationRecordDependent compositeAssociationRecord in testEntitiesClient->/compositeassociationrecord.get(CompositeAssociationRecordDependent)
+        select compositeAssociationRecord;
+    test:assertEquals(compositeAssociationRecordsDependent, [
+        {randomField: compositeAssociationRecord1.randomField, alltypesidrecordIntType: compositeAssociationRecord1.alltypesidrecordIntType, alltypesidrecordDecimalType: compositeAssociationRecord1.alltypesidrecordDecimalType, alltypesidrecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}}, 
+        {randomField: compositeAssociationRecord2.randomField, alltypesidrecordIntType: compositeAssociationRecord2.alltypesidrecordIntType, alltypesidrecordDecimalType: compositeAssociationRecord2.alltypesidrecordDecimalType, alltypesidrecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}}
+    ]);
 
     // update
     retrievedRecord1 = check testEntitiesClient->/compositeassociationrecord/[compositeAssociationRecord1.id].put({randomField: "test1Updated"});

--- a/ballerina/tests/id-fields-tests.bal
+++ b/ballerina/tests/id-fields-tests.bal
@@ -16,6 +16,10 @@
 
 import ballerina/test;
 
+public type IntIdRecordDependent record {|
+    string randomField;
+|};
+
 @test:Config {
     groups: ["id-fields"]
 }
@@ -46,10 +50,19 @@ function intIdFieldTest() returns error? {
     IntIdRecord retrievedRecord1 = check testEntitiesClient->/intidrecord/[intIdRecord1.id].get();
     test:assertEquals(intIdRecord1, retrievedRecord1);
 
+    // read one dependent
+    IntIdRecordDependent retrievedRecord1Dependent = check testEntitiesClient->/intidrecord/[intIdRecord1.id].get();
+    test:assertEquals({randomField: intIdRecord1.randomField}, retrievedRecord1Dependent);
+
     // read
     IntIdRecord[] intIdRecords = check from IntIdRecord intIdRecord in testEntitiesClient->/intidrecord.get(IntIdRecord)
         select intIdRecord;
     test:assertEquals(intIdRecords, [intIdRecord1, intIdRecord2, intIdRecord3]);
+
+    // read dependent
+    IntIdRecordDependent[] intIdRecordsDependent = check from IntIdRecordDependent intIdRecord in testEntitiesClient->/intidrecord.get(IntIdRecordDependent)
+        select intIdRecord;
+    test:assertEquals(intIdRecordsDependent, [{randomField: intIdRecord1.randomField}, {randomField: intIdRecord2.randomField}, {randomField: intIdRecord3.randomField}]);
 
     // update
     retrievedRecord1 = check testEntitiesClient->/intidrecord/[intIdRecord1.id].put({randomField: intIdRecord1Updated.randomField});
@@ -66,6 +79,10 @@ function intIdFieldTest() returns error? {
 
     check testEntitiesClient.close();
 }
+
+public type StringIdRecordDependent record {|
+    string randomField;
+|};
 
 @test:Config {
     groups: ["id-fields"]
@@ -97,10 +114,19 @@ function stringIdFieldTest() returns error? {
     StringIdRecord retrievedRecord1 = check testEntitiesClient->/stringidrecord/[stringIdRecord1.id].get();
     test:assertEquals(stringIdRecord1, retrievedRecord1);
 
+    // read one dependent
+    StringIdRecordDependent retrievedRecord1Dependent = check testEntitiesClient->/stringidrecord/[stringIdRecord1.id].get();
+    test:assertEquals({randomField: stringIdRecord1.randomField}, retrievedRecord1Dependent);
+
     // read
     StringIdRecord[] stringIdRecords = check from StringIdRecord stringIdRecord in testEntitiesClient->/stringidrecord.get(StringIdRecord)
         select stringIdRecord;
     test:assertEquals(stringIdRecords, [stringIdRecord1, stringIdRecord2, stringIdRecord3]);
+
+    // read dependent
+    StringIdRecordDependent[] stringIdRecordsDependent = check from StringIdRecordDependent stringIdRecord in testEntitiesClient->/stringidrecord.get(StringIdRecordDependent)
+        select stringIdRecord;
+    test:assertEquals(stringIdRecordsDependent, [{randomField: stringIdRecord1.randomField}, {randomField: stringIdRecord2.randomField}, {randomField: stringIdRecord3.randomField}]);
 
     // update
     retrievedRecord1 = check testEntitiesClient->/stringidrecord/[stringIdRecord1.id].put({randomField: stringIdRecord1Updated.randomField});
@@ -117,6 +143,10 @@ function stringIdFieldTest() returns error? {
 
     check testEntitiesClient.close();
 }
+
+public type FloatIdRecordDependent record {|
+    string randomField;
+|};
 
 @test:Config {
     groups: ["id-fields"]
@@ -148,10 +178,19 @@ function floatIdFieldTest() returns error? {
     FloatIdRecord retrievedRecord1 = check testEntitiesClient->/floatidrecord/[floatIdRecord1.id].get();
     test:assertEquals(floatIdRecord1, retrievedRecord1);
 
+    // read one dependent
+    FloatIdRecordDependent retrievedRecord1Dependent = check testEntitiesClient->/floatidrecord/[floatIdRecord1.id].get();
+    test:assertEquals({randomField: floatIdRecord1.randomField}, retrievedRecord1Dependent);
+
     // read
     FloatIdRecord[] floatIdRecords = check from FloatIdRecord floatIdRecord in testEntitiesClient->/floatidrecord.get(FloatIdRecord)
         select floatIdRecord;
     test:assertEquals(floatIdRecords, [floatIdRecord1, floatIdRecord2, floatIdRecord3]);
+
+    // read dependent
+    FloatIdRecordDependent[] floatIdRecordsDependent = check from FloatIdRecordDependent floatIdRecord in testEntitiesClient->/floatidrecord.get(FloatIdRecordDependent)
+        select floatIdRecord;
+    test:assertEquals(floatIdRecordsDependent, [{randomField: floatIdRecord1.randomField}, {randomField: floatIdRecord2.randomField}, {randomField: floatIdRecord3.randomField}]);
 
     // update
     retrievedRecord1 = check testEntitiesClient->/floatidrecord/[floatIdRecord1.id].put({randomField: floatIdRecord1Updated.randomField});
@@ -166,6 +205,10 @@ function floatIdFieldTest() returns error? {
         select floatIdRecord;
     test:assertEquals(floatIdRecords, [floatIdRecord1Updated, floatIdRecord3]);
 }
+
+public type DecimalIdRecordDependent record {|
+    string randomField;
+|};
 
 @test:Config {
     groups: ["id-fields"]
@@ -197,10 +240,19 @@ function decimalIdFieldTest() returns error? {
     DecimalIdRecord retrievedRecord1 = check testEntitiesClient->/decimalidrecord/[decimalIdRecord1.id].get();
     test:assertEquals(decimalIdRecord1, retrievedRecord1);
 
+    // read one dependent
+    DecimalIdRecordDependent retrievedRecord1Dependent = check testEntitiesClient->/decimalidrecord/[decimalIdRecord1.id].get();
+    test:assertEquals({randomField: decimalIdRecord1.randomField}, retrievedRecord1Dependent);
+
     // read
     DecimalIdRecord[] decimalIdRecords = check from DecimalIdRecord decimalIdRecord in testEntitiesClient->/decimalidrecord.get(DecimalIdRecord)
         select decimalIdRecord;
     test:assertEquals(decimalIdRecords, [decimalIdRecord1, decimalIdRecord2, decimalIdRecord3]);
+
+    // read dependent
+    DecimalIdRecordDependent[] decimalIdRecordsDependent = check from DecimalIdRecordDependent decimalIdRecord in testEntitiesClient->/decimalidrecord.get(DecimalIdRecordDependent)
+        select decimalIdRecord;
+    test:assertEquals(decimalIdRecordsDependent, [{randomField: decimalIdRecord1.randomField}, {randomField: decimalIdRecord2.randomField}, {randomField: decimalIdRecord3.randomField}]);
 
     // update
     retrievedRecord1 = check testEntitiesClient->/decimalidrecord/[decimalIdRecord1.id].put({randomField: decimalIdRecord1Updated.randomField});
@@ -217,6 +269,10 @@ function decimalIdFieldTest() returns error? {
 
     check testEntitiesClient.close();
 }
+
+public type BooleanIdRecordDependent record {|
+    string randomField;
+|};
 
 @test:Config {
     groups: ["id-fields"]
@@ -244,10 +300,19 @@ function booleanIdFieldTest() returns  error? {
     BooleanIdRecord retrievedRecord1 = check testEntitiesClient->/booleanidrecord/[booleanIdRecord1.id].get();
     test:assertEquals(booleanIdRecord1, retrievedRecord1);
 
+    // read one dependent
+    BooleanIdRecordDependent retrievedRecord1Dependent = check testEntitiesClient->/booleanidrecord/[booleanIdRecord1.id].get();
+    test:assertEquals({randomField: booleanIdRecord1.randomField}, retrievedRecord1Dependent);
+
     // read
     BooleanIdRecord[] booleanIdRecords = check from BooleanIdRecord booleanIdRecord in testEntitiesClient->/booleanidrecord.get(BooleanIdRecord)
         select booleanIdRecord;
     test:assertEquals(booleanIdRecords, [booleanIdRecord2, booleanIdRecord1]);
+
+    // read dependent
+    BooleanIdRecordDependent[] booleanIdRecordsDependent = check from BooleanIdRecordDependent booleanIdRecord in testEntitiesClient->/booleanidrecord.get(BooleanIdRecordDependent)
+        select booleanIdRecord;
+    test:assertEquals(booleanIdRecordsDependent, [{randomField: booleanIdRecord2.randomField}, {randomField: booleanIdRecord1.randomField}]);
 
     // update
     retrievedRecord1 = check testEntitiesClient->/booleanidrecord/[booleanIdRecord1.id].put({randomField: booleanIdRecord1Updated.randomField});
@@ -264,6 +329,10 @@ function booleanIdFieldTest() returns  error? {
 
     check testEntitiesClient.close();
 }
+
+public type AllTypesIdRecordDependent record {|
+    string randomField;
+|};
 
 @test:Config {
     groups: ["id-fields"]
@@ -304,10 +373,19 @@ function allTypesIdFieldTest() returns error? {
     AllTypesIdRecord retrievedRecord1 = check testEntitiesClient->/alltypesidrecord/[allTypesIdRecord1.floatType]/[allTypesIdRecord1.decimalType]/[allTypesIdRecord1.booleanType]/[allTypesIdRecord1.intType]/[allTypesIdRecord1.stringType].get();
     test:assertEquals(allTypesIdRecord1, retrievedRecord1);
 
+    // read one dependent
+    AllTypesIdRecordDependent retrievedRecord1Dependent = check testEntitiesClient->/alltypesidrecord/[allTypesIdRecord1.floatType]/[allTypesIdRecord1.decimalType]/[allTypesIdRecord1.booleanType]/[allTypesIdRecord1.intType]/[allTypesIdRecord1.stringType].get();
+    test:assertEquals({randomField: allTypesIdRecord1.randomField}, retrievedRecord1Dependent);
+
     // read
     AllTypesIdRecord[] allTypesIdRecords = check from AllTypesIdRecord allTypesIdRecord in testEntitiesClient->/alltypesidrecord.get(AllTypesIdRecord)
         select allTypesIdRecord;
     test:assertEquals(allTypesIdRecords, [allTypesIdRecord2, allTypesIdRecord1]);
+
+    // read dependent
+    AllTypesIdRecordDependent[] allTypesIdRecordsDependent = check from AllTypesIdRecordDependent allTypesIdRecord in testEntitiesClient->/alltypesidrecord.get(AllTypesIdRecordDependent)
+        select allTypesIdRecord;
+    test:assertEquals(allTypesIdRecordsDependent, [{randomField: allTypesIdRecord2.randomField}, {randomField: allTypesIdRecord1.randomField}]);
 
     // update
     retrievedRecord1 = check testEntitiesClient->/alltypesidrecord/[allTypesIdRecord1.floatType]/[allTypesIdRecord1.decimalType]/[allTypesIdRecord1.booleanType]/[allTypesIdRecord1.intType]/[allTypesIdRecord1.stringType].put({randomField: allTypesIdRecord1Updated.randomField});
@@ -325,8 +403,20 @@ function allTypesIdFieldTest() returns error? {
     check testEntitiesClient.close();
 }
 
+public type CompositeAssociationRecordDependent record {|
+    string randomField;
+    int alltypesidrecordIntType;
+    decimal alltypesidrecordDecimalType;
+    record {|
+        int intType;
+        string stringType;
+        boolean booleanType;
+        string randomField;
+    |} alltypesidrecord;
+|};
+
 @test:Config {
-    groups: ["id-fields", "associations"],
+    groups: ["id-fieldsx", "associations"],
     dependsOn : [allTypesIdFieldTest]
 }
 function compositeAssociationsTest() returns error? {
@@ -362,6 +452,15 @@ function compositeAssociationsTest() returns error? {
         alltypesidrecordDecimalType: 1.1d
     };
 
+    AllTypesIdRecordOptionalized allTypesIdRecord1 = {
+        intType: 1,
+        stringType: "id-1",
+        floatType: 1.0,
+        booleanType: true,
+        decimalType: 1.1d,
+        randomField: "test1Updated"
+    };
+
     // create
     string[] ids = check testEntitiesClient->/compositeassociationrecord.post([compositeAssociationRecord1, compositeAssociationRecord2]);
     test:assertEquals(ids, [compositeAssociationRecord1.id, compositeAssociationRecord2.id]);
@@ -370,10 +469,27 @@ function compositeAssociationsTest() returns error? {
     CompositeAssociationRecord retrievedRecord1 = check testEntitiesClient->/compositeassociationrecord/[compositeAssociationRecord1.id].get();
     test:assertEquals(compositeAssociationRecord1, retrievedRecord1);
 
+    // read one dependent
+    CompositeAssociationRecordDependent retrievedRecord1Dependent = check testEntitiesClient->/compositeassociationrecord/[compositeAssociationRecord1.id].get();
+    test:assertEquals({
+        randomField: compositeAssociationRecord1.randomField, 
+        alltypesidrecordIntType: compositeAssociationRecord1.alltypesidrecordIntType, 
+        alltypesidrecordDecimalType: compositeAssociationRecord1.alltypesidrecordDecimalType,
+        alltypesidrecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}
+    }, retrievedRecord1Dependent);
+
     // read
     CompositeAssociationRecord[] compositeAssociationRecords = check from CompositeAssociationRecord compositeAssociationRecord in testEntitiesClient->/compositeassociationrecord.get(CompositeAssociationRecord)
         select compositeAssociationRecord;
     test:assertEquals(compositeAssociationRecords, [compositeAssociationRecord1, compositeAssociationRecord2]);
+
+    // // read dependent
+    // CompositeAssociationRecordDependent[] compositeAssociationRecordsDependent = check from CompositeAssociationRecordDependent compositeAssociationRecord in testEntitiesClient->/compositeassociationrecord.get(CompositeAssociationRecordDependent)
+    //     select compositeAssociationRecord;
+    // test:assertEquals(compositeAssociationRecordsDependent, [
+    //     {randomField: compositeAssociationRecord1.randomField, alltypesidrecordIntType: compositeAssociationRecord1.alltypesidrecordIntType, alltypesidrecordDecimalType: compositeAssociationRecord1.alltypesidrecordDecimalType, allTypesIdRecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}}, 
+    //     {randomField: compositeAssociationRecord2.randomField, alltypesidrecordIntType: compositeAssociationRecord2.alltypesidrecordIntType, alltypesidrecordDecimalType: compositeAssociationRecord2.alltypesidrecordDecimalType, allTypesIdRecord: {intType: allTypesIdRecord1.intType, stringType: allTypesIdRecord1.stringType, booleanType: allTypesIdRecord1.booleanType, randomField: allTypesIdRecord1.randomField}}
+    // ]);
 
     // update
     retrievedRecord1 = check testEntitiesClient->/compositeassociationrecord/[compositeAssociationRecord1.id].put({randomField: "test1Updated"});

--- a/ballerina/tests/rainier_generated_client.bal
+++ b/ballerina/tests/rainier_generated_client.bal
@@ -1,5 +1,5 @@
-import ballerinax/mysql;
 import ballerina/jballerina.java;
+import ballerinax/mysql;
 
 const EMPLOYEE = "employee";
 const WORKSPACE = "workspace";
@@ -31,7 +31,7 @@ public client class RainierClient {
                 "department.deptName": {relation: {entityName: "department", refField: "deptName"}},
                 "workspace.workspaceId": {relation: {entityName: "workspace", refField: "workspaceId"}},
                 "workspace.workspaceType": {relation: {entityName: "workspace", refField: "workspaceType"}},
-                "workspace.locationBuildingCode": {relation: {entityName: "workspace", refField: "locationBuildingCode"}}
+                "workspace.locationBuildingCode": {relation: {entityName: "location", refField: "locationBuildingCode"}}
             },
             keyFields: ["empNo"],
             joinMetadata: {
@@ -46,20 +46,20 @@ public client class RainierClient {
                 workspaceId: {columnName: "workspaceId"},
                 workspaceType: {columnName: "workspaceType"},
                 locationBuildingCode: {columnName: "locationBuildingCode"},
-                "location.buildingCode": {relation: {entityName: "building", refField: "buildingCode"}},
-                "location.city": {relation: {entityName: "building", refField: "city"}},
-                "location.state": {relation: {entityName: "building", refField: "state"}},
-                "location.country": {relation: {entityName: "building", refField: "country"}},
-                "location.postalCode": {relation: {entityName: "building", refField: "postalCode"}},
-                "location.type": {relation: {entityName: "building", refField: "type"}},
-                "employees[].empNo": {relation: {entityName: "employee", refField: "empNo"}},
-                "employees[].firstName": {relation: {entityName: "employee", refField: "firstName"}},
-                "employees[].lastName": {relation: {entityName: "employee", refField: "lastName"}},
-                "employees[].birthDate": {relation: {entityName: "employee", refField: "birthDate"}},
-                "employees[].gender": {relation: {entityName: "employee", refField: "gender"}},
-                "employees[].hireDate": {relation: {entityName: "employee", refField: "hireDate"}},
-                "employees[].departmentDeptNo": {relation: {entityName: "employee", refField: "departmentDeptNo"}},
-                "employees[].workspaceWorkspaceId": {relation: {entityName: "employee", refField: "workspaceWorkspaceId"}}
+                "location.buildingCode": {relation: {entityName: "location", refField: "buildingCode"}},
+                "location.city": {relation: {entityName: "location", refField: "city"}},
+                "location.state": {relation: {entityName: "location", refField: "state"}},
+                "location.country": {relation: {entityName: "location", refField: "country"}},
+                "location.postalCode": {relation: {entityName: "location", refField: "postalCode"}},
+                "location.type": {relation: {entityName: "location", refField: "type"}},
+                "employees[].empNo": {relation: {entityName: "employees", refField: "empNo"}},
+                "employees[].firstName": {relation: {entityName: "employees", refField: "firstName"}},
+                "employees[].lastName": {relation: {entityName: "employees", refField: "lastName"}},
+                "employees[].birthDate": {relation: {entityName: "employees", refField: "birthDate"}},
+                "employees[].gender": {relation: {entityName: "employees", refField: "gender"}},
+                "employees[].hireDate": {relation: {entityName: "employees", refField: "hireDate"}},
+                "employees[].departmentDeptNo": {relation: {entityName: "department", refField: "departmentDeptNo"}},
+                "employees[].workspaceWorkspaceId": {relation: {entityName: "workspace", refField: "workspaceWorkspaceId"}}
             },
             keyFields: ["workspaceId"],
             joinMetadata: {
@@ -77,14 +77,12 @@ public client class RainierClient {
                 country: {columnName: "country"},
                 postalCode: {columnName: "postalCode"},
                 'type: {columnName: "type"},
-                "workspaces[].workspaceId": {relation: {entityName: "workspace", refField: "workspaceId"}},
-                "workspaces[].workspaceType": {relation: {entityName: "workspace", refField: "workspaceType"}},
-                "workspaces[].locationBuildingCode": {relation: {entityName: "workspace", refField: "locationBuildingCode"}}
+                "workspaces[].workspaceId": {relation: {entityName: "workspaces", refField: "workspaceId"}},
+                "workspaces[].workspaceType": {relation: {entityName: "workspaces", refField: "workspaceType"}},
+                "workspaces[].locationBuildingCode": {relation: {entityName: "location", refField: "locationBuildingCode"}}
             },
             keyFields: ["buildingCode"],
-            joinMetadata: {
-                workspaces: {entity: Workspace, fieldName: "workspaces", refTable: "Workspace", refColumns: ["locationBuildingCode"], joinColumns: ["buildingCode"], 'type: MANY_TO_ONE}
-            }
+            joinMetadata: {workspaces: {entity: Workspace, fieldName: "workspaces", refTable: "Workspace", refColumns: ["locationBuildingCode"], joinColumns: ["buildingCode"], 'type: MANY_TO_ONE}}
         },
         "department": {
             entityName: "Department",
@@ -92,19 +90,17 @@ public client class RainierClient {
             fieldMetadata: {
                 deptNo: {columnName: "deptNo"},
                 deptName: {columnName: "deptName"},
-                "employees[].empNo": {relation: {entityName: "employee", refField: "empNo"}},
-                "employees[].firstName": {relation: {entityName: "employee", refField: "firstName"}},
-                "employees[].lastName": {relation: {entityName: "employee", refField: "lastName"}},
-                "employees[].birthDate": {relation: {entityName: "employee", refField: "birthDate"}},
-                "employees[].gender": {relation: {entityName: "employee", refField: "gender"}},
-                "employees[].hireDate": {relation: {entityName: "employee", refField: "hireDate"}},
-                "employees[].departmentDeptNo": {relation: {entityName: "employee", refField: "departmentDeptNo"}},
-                "employees[].workspaceWorkspaceId": {relation: {entityName: "employee", refField: "workspaceWorkspaceId"}}
+                "employees[].empNo": {relation: {entityName: "employees", refField: "empNo"}},
+                "employees[].firstName": {relation: {entityName: "employees", refField: "firstName"}},
+                "employees[].lastName": {relation: {entityName: "employees", refField: "lastName"}},
+                "employees[].birthDate": {relation: {entityName: "employees", refField: "birthDate"}},
+                "employees[].gender": {relation: {entityName: "employees", refField: "gender"}},
+                "employees[].hireDate": {relation: {entityName: "employees", refField: "hireDate"}},
+                "employees[].departmentDeptNo": {relation: {entityName: "employees", refField: "departmentDeptNo"}},
+                "employees[].workspaceWorkspaceId": {relation: {entityName: "employees", refField: "workspaceWorkspaceId"}}
             },
             keyFields: ["deptNo"],
-            joinMetadata: {
-                employees: {entity: Employee, fieldName: "employees", refTable: "Employee", refColumns: ["departmentDeptNo"], joinColumns: ["deptNo"], 'type: MANY_TO_ONE}
-            }
+            joinMetadata: {employees: {entity: Employee, fieldName: "employees", refTable: "Employee", refColumns: ["departmentDeptNo"], joinColumns: ["deptNo"], 'type: MANY_TO_ONE}}
         },
         "orderitem": {
             entityName: "OrderItem",
@@ -151,8 +147,8 @@ public client class RainierClient {
             select inserted.empNo;
     }
 
-    isolated resource function put employee/[string empNo](EmployeeUpdate data) returns Employee|Error {
-        _ = check self.persistClients.get(EMPLOYEE).runUpdateQuery(empNo, data);
+    isolated resource function put employee/[string empNo](EmployeeUpdate value) returns Employee|Error {
+        _ = check self.persistClients.get(EMPLOYEE).runUpdateQuery(empNo, value);
         return self->/employee/[empNo].get();
     }
 
@@ -167,7 +163,7 @@ public client class RainierClient {
         name: "query"
     } external;
 
-    isolated resource function get workspace/[string workspaceId](WorkspaceTargetType targetType = <>) returns targetType|Error  = @java:Method {
+    isolated resource function get workspace/[string workspaceId](WorkspaceTargetType targetType = <>) returns targetType|Error = @java:Method {
         'class: "io.ballerina.stdlib.persist.QueryProcessor",
         name: "queryOne",
         paramTypes: ["io.ballerina.runtime.api.Environment", "io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "io.ballerina.runtime.api.values.BTypedesc"]
@@ -179,8 +175,8 @@ public client class RainierClient {
             select inserted.workspaceId;
     }
 
-    isolated resource function put workspace/[string workspaceId](WorkspaceUpdate data) returns Workspace|Error {
-        _ = check self.persistClients.get(WORKSPACE).runUpdateQuery(workspaceId, data);
+    isolated resource function put workspace/[string workspaceId](WorkspaceUpdate value) returns Workspace|Error {
+        _ = check self.persistClients.get(WORKSPACE).runUpdateQuery(workspaceId, value);
         return self->/workspace/[workspaceId].get();
     }
 
@@ -195,12 +191,11 @@ public client class RainierClient {
         name: "query"
     } external;
 
-    isolated resource function get building/[string buildingCode](BuildingTargetType targetType = <>) returns targetType|Error  = @java:Method {
+    isolated resource function get building/[string buildingCode](BuildingTargetType targetType = <>) returns targetType|Error = @java:Method {
         'class: "io.ballerina.stdlib.persist.QueryProcessor",
         name: "queryOne",
         paramTypes: ["io.ballerina.runtime.api.Environment", "io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "io.ballerina.runtime.api.values.BTypedesc"]
     } external;
-
 
     isolated resource function post building(BuildingInsert[] data) returns string[]|Error {
         _ = check self.persistClients.get(BUILDING).runBatchInsertQuery(data);
@@ -208,8 +203,8 @@ public client class RainierClient {
             select inserted.buildingCode;
     }
 
-    isolated resource function put building/[string buildingCode](BuildingUpdate data) returns Building|Error {
-        _ = check self.persistClients.get(BUILDING).runUpdateQuery(buildingCode, data);
+    isolated resource function put building/[string buildingCode](BuildingUpdate value) returns Building|Error {
+        _ = check self.persistClients.get(BUILDING).runUpdateQuery(buildingCode, value);
         return self->/building/[buildingCode].get();
     }
 
@@ -236,8 +231,8 @@ public client class RainierClient {
             select inserted.deptNo;
     }
 
-    isolated resource function put department/[string deptNo](DepartmentUpdate data) returns Department|Error {
-        _ = check self.persistClients.get(DEPARTMENT).runUpdateQuery(deptNo, data);
+    isolated resource function put department/[string deptNo](DepartmentUpdate value) returns Department|Error {
+        _ = check self.persistClients.get(DEPARTMENT).runUpdateQuery(deptNo, value);
         return self->/department/[deptNo].get();
     }
 
@@ -264,14 +259,14 @@ public client class RainierClient {
             select [inserted.orderId, inserted.itemId];
     }
 
-    isolated resource function put orderitem/[string orderId]/[string itemId](OrderItemUpdate data) returns OrderItem|Error {
-        _ = check self.persistClients.get(ORDER_ITEM).runUpdateQuery({orderId: orderId, itemId: itemId}, data);
+    isolated resource function put orderitem/[string orderId]/[string itemId](OrderItemUpdate value) returns OrderItem|Error {
+        _ = check self.persistClients.get(ORDER_ITEM).runUpdateQuery({"orderId": orderId, "itemId": itemId}, value);
         return self->/orderitem/[orderId]/[itemId].get();
     }
 
     isolated resource function delete orderitem/[string orderId]/[string itemId]() returns OrderItem|Error {
         OrderItem result = check self->/orderitem/[orderId]/[itemId].get();
-        _ = check self.persistClients.get(ORDER_ITEM).runDeleteQuery({orderId: orderId, itemId: itemId});
+        _ = check self.persistClients.get(ORDER_ITEM).runDeleteQuery({"orderId": orderId, "itemId": itemId});
         return result;
     }
 

--- a/ballerina/tests/rainier_generated_types.bal
+++ b/ballerina/tests/rainier_generated_types.bal
@@ -104,13 +104,13 @@ public type BuildingOptionalized record {|
 |};
 
 public type WorkspaceOptionalized record {|
-    readonly string workspaceId?;
+    string workspaceId?;
     string workspaceType?;
     string locationBuildingCode?;
 |};
 
 public type EmployeeOptionalized record {|
-    readonly string empNo?;
+    string empNo?;
     string firstName?;
     string lastName?;
     time:Date birthDate?;
@@ -121,13 +121,13 @@ public type EmployeeOptionalized record {|
 |};
 
 public type DepartmentOptionalized record {|
-    readonly string deptNo?;
+    string deptNo?;
     string deptName?;
 |};
 
 public type OrderItemOptionalized record {|
-    readonly string orderId?;
-    readonly string itemId?;
+    string orderId?;
+    string itemId?;
     int quantity?;
     string notes?;
 |};

--- a/ballerina/tests/rainier_generated_types.bal
+++ b/ballerina/tests/rainier_generated_types.bal
@@ -1,8 +1,3 @@
-// AUTO-GENERATED FILE. DO NOT MODIFY.
-
-// This file is an auto-generated file by Ballerina persistence layer for rainier.
-// It should not be modified by hand.
-
 import ballerina/time;
 
 public type Employee record {|
@@ -15,6 +10,25 @@ public type Employee record {|
     string departmentDeptNo;
     string workspaceWorkspaceId;
 |};
+
+public type EmployeeOptionalized record {|
+    string empNo?;
+    string firstName?;
+    string lastName?;
+    time:Date birthDate?;
+    string gender?;
+    time:Date hireDate?;
+    string departmentDeptNo?;
+    string workspaceWorkspaceId?;
+|};
+
+public type EmployeeWithRelations record {|
+    *EmployeeOptionalized;
+    DepartmentOptionalized department?;
+    WorkspaceOptionalized workspace?;
+|};
+
+public type EmployeeTargetType typedesc<EmployeeWithRelations>;
 
 public type EmployeeInsert Employee;
 
@@ -34,6 +48,20 @@ public type Workspace record {|
     string locationBuildingCode;
 |};
 
+public type WorkspaceOptionalized record {|
+    string workspaceId?;
+    string workspaceType?;
+    string locationBuildingCode?;
+|};
+
+public type WorkspaceWithRelations record {|
+    *WorkspaceOptionalized;
+    BuildingOptionalized location?;
+    EmployeeOptionalized[] employees?;
+|};
+
+public type WorkspaceTargetType typedesc<WorkspaceWithRelations>;
+
 public type WorkspaceInsert Workspace;
 
 public type WorkspaceUpdate record {|
@@ -50,6 +78,22 @@ public type Building record {|
     string 'type;
 |};
 
+public type BuildingOptionalized record {|
+    string buildingCode?;
+    string city?;
+    string state?;
+    string country?;
+    string postalCode?;
+    string 'type?;
+|};
+
+public type BuildingWithRelations record {|
+    *BuildingOptionalized;
+    WorkspaceOptionalized[] workspaces?;
+|};
+
+public type BuildingTargetType typedesc<BuildingWithRelations>;
+
 public type BuildingInsert Building;
 
 public type BuildingUpdate record {|
@@ -65,6 +109,18 @@ public type Department record {|
     string deptName;
 |};
 
+public type DepartmentOptionalized record {|
+    string deptNo?;
+    string deptName?;
+|};
+
+public type DepartmentWithRelations record {|
+    *DepartmentOptionalized;
+    EmployeeOptionalized[] employees?;
+|};
+
+public type DepartmentTargetType typedesc<DepartmentWithRelations>;
+
 public type DepartmentInsert Department;
 
 public type DepartmentUpdate record {|
@@ -78,53 +134,6 @@ public type OrderItem record {|
     string notes;
 |};
 
-public type OrderItemInsert OrderItem;
-
-public type OrderItemUpdate record {|
-    int quantity?;
-    string notes?;
-|};
-
-public type Customer record {|
-    readonly string customerId;
-    string firstName;
-    string lastName;
-    string email;
-    string phone;
-    string address;
-|};
-
-public type BuildingOptionalized record {|
-    string buildingCode?;
-    string city?;
-    string state?;
-    string country?;
-    string postalCode?;
-    string 'type?;
-|};
-
-public type WorkspaceOptionalized record {|
-    string workspaceId?;
-    string workspaceType?;
-    string locationBuildingCode?;
-|};
-
-public type EmployeeOptionalized record {|
-    string empNo?;
-    string firstName?;
-    string lastName?;
-    time:Date birthDate?;
-    string gender?;
-    time:Date hireDate?;
-    string departmentDeptNo?;
-    string workspaceWorkspaceId?;
-|};
-
-public type DepartmentOptionalized record {|
-    string deptNo?;
-    string deptName?;
-|};
-
 public type OrderItemOptionalized record {|
     string orderId?;
     string itemId?;
@@ -132,34 +141,11 @@ public type OrderItemOptionalized record {|
     string notes?;
 |};
 
-public type EmployeeWithRelations record {|
-    *EmployeeOptionalized;
-    DepartmentOptionalized department?;
-    WorkspaceOptionalized workspace?;
-|};
-
-public type DepartmentWithRelations record {|
-    *DepartmentOptionalized;
-    EmployeeOptionalized[] employees?;
-|};
-
-public type WorkspaceWithRelations record {|
-    *WorkspaceOptionalized;
-    BuildingOptionalized location?;
-    EmployeeOptionalized[] employees?;
-|};
-
-public type BuildingWithRelations record {|
-    *BuildingOptionalized;
-    WorkspaceOptionalized[] workspaces?;
-|};
-
-public type EmployeeTargetType typedesc<EmployeeWithRelations>;
-
-public type DepartmentTargetType typedesc<DepartmentWithRelations>;
-
-public type WorkspaceTargetType typedesc<WorkspaceWithRelations>;
-
-public type BuildingTargetType typedesc<BuildingWithRelations>;
-
 public type OrderItemTargetType typedesc<OrderItemOptionalized>;
+
+public type OrderItemInsert OrderItem;
+
+public type OrderItemUpdate record {|
+    int quantity?;
+    string notes?;
+|};

--- a/ballerina/tests/rainier_generated_types.bal
+++ b/ballerina/tests/rainier_generated_types.bal
@@ -95,7 +95,7 @@ public type Customer record {|
 |};
 
 public type BuildingOptionalized record {|
-    readonly string buildingCode?;
+    string buildingCode?;
     string city?;
     string state?;
     string country?;

--- a/ballerina/tests/test_entities_generated_client.bal
+++ b/ballerina/tests/test_entities_generated_client.bal
@@ -1,5 +1,5 @@
-import ballerinax/mysql;
 import ballerina/jballerina.java;
+import ballerinax/mysql;
 
 const ALL_TYPES = "alltypes";
 const STRING_ID_RECORD = "stringidrecord";
@@ -99,17 +99,15 @@ public client class TestEntitiesClient {
                 alltypesidrecordFloatType: {columnName: "alltypesidrecordFloatType"},
                 alltypesidrecordDecimalType: {columnName: "alltypesidrecordDecimalType"},
                 alltypesidrecordStringType: {columnName: "alltypesidrecordStringType"},
-                "alltypesidrecord.booleanType": {relation: {entityName: "alltypesidrecord", refField: "booleanType"}},
-                "alltypesidrecord.intType": {relation: {entityName: "alltypesidrecord", refField: "intType"}},
-                "alltypesidrecord.floatType": {relation: {entityName: "alltypesidrecord", refField: "floatType"}},
-                "alltypesidrecord.decimalType": {relation: {entityName: "alltypesidrecord", refField: "decimalType"}},
-                "alltypesidrecord.stringType": {relation: {entityName: "alltypesidrecord", refField: "stringType"}},
-                "alltypesidrecord.randomField": {relation: {entityName: "alltypesidrecord", refField: "randomField"}}
+                "allTypesIdRecord.booleanType": {relation: {entityName: "allTypesIdRecord", refField: "booleanType"}},
+                "allTypesIdRecord.intType": {relation: {entityName: "allTypesIdRecord", refField: "intType"}},
+                "allTypesIdRecord.floatType": {relation: {entityName: "allTypesIdRecord", refField: "floatType"}},
+                "allTypesIdRecord.decimalType": {relation: {entityName: "allTypesIdRecord", refField: "decimalType"}},
+                "allTypesIdRecord.stringType": {relation: {entityName: "allTypesIdRecord", refField: "stringType"}},
+                "allTypesIdRecord.randomField": {relation: {entityName: "allTypesIdRecord", refField: "randomField"}}
             },
             keyFields: ["id"],
-            joinMetadata: {
-                alltypesidrecord: {entity: AllTypesIdRecord, fieldName: "alltypesidrecord", refTable: "AllTypesIdRecord", refColumns: ["booleanType", "intType", "floatType", "decimalType", "stringType"], joinColumns: ["alltypesidrecordBooleanType", "alltypesidrecordIntType", "alltypesidrecordFloatType", "alltypesidrecordDecimalType", "alltypesidrecordStringType"], 'type: ONE_TO_ONE}
-            }
+            joinMetadata: {allTypesIdRecord: {entity: AllTypesIdRecord, fieldName: "allTypesIdRecord", refTable: "AllTypesIdRecord", refColumns: ["booleanType", "intType", "floatType", "decimalType", "stringType"], joinColumns: ["alltypesidrecordBooleanType", "alltypesidrecordIntType", "alltypesidrecordFloatType", "alltypesidrecordDecimalType", "alltypesidrecordStringType"], 'type: ONE_TO_ONE}}
         },
         "alltypesidrecord": {
             entityName: "AllTypesIdRecord",
@@ -121,18 +119,16 @@ public client class TestEntitiesClient {
                 decimalType: {columnName: "decimalType"},
                 stringType: {columnName: "stringType"},
                 randomField: {columnName: "randomField"},
-                "compositeassociationrecord.id": {relation: {entityName: "compositeassociationrecord", refField: "id"}},
-                "compositeassociationrecord.randomField": {relation: {entityName: "compositeassociationrecord", refField: "randomField"}},
-                "compositeassociationrecord.alltypesidrecordBooleanType": {relation: {entityName: "compositeassociationrecord", refField: "alltypesidrecordBooleanType"}},
-                "compositeassociationrecord.alltypesidrecordIntType": {relation: {entityName: "compositeassociationrecord", refField: "alltypesidrecordIntType"}},
-                "compositeassociationrecord.alltypesidrecordFloatType": {relation: {entityName: "compositeassociationrecord", refField: "alltypesidrecordFloatType"}},
-                "compositeassociationrecord.alltypesidrecordDecimalType": {relation: {entityName: "compositeassociationrecord", refField: "alltypesidrecordDecimalType"}},
-                "compositeassociationrecord.alltypesidrecordStringType": {relation: {entityName: "compositeassociationrecord", refField: "alltypesidrecordStringType"}}
+                "compositeAssociationRecord.id": {relation: {entityName: "compositeAssociationRecord", refField: "id"}},
+                "compositeAssociationRecord.randomField": {relation: {entityName: "compositeAssociationRecord", refField: "randomField"}},
+                "compositeAssociationRecord.alltypesidrecordBooleanType": {relation: {entityName: "allTypesIdRecord", refField: "alltypesidrecordBooleanType"}},
+                "compositeAssociationRecord.alltypesidrecordIntType": {relation: {entityName: "allTypesIdRecord", refField: "alltypesidrecordIntType"}},
+                "compositeAssociationRecord.alltypesidrecordFloatType": {relation: {entityName: "allTypesIdRecord", refField: "alltypesidrecordFloatType"}},
+                "compositeAssociationRecord.alltypesidrecordDecimalType": {relation: {entityName: "allTypesIdRecord", refField: "alltypesidrecordDecimalType"}},
+                "compositeAssociationRecord.alltypesidrecordStringType": {relation: {entityName: "allTypesIdRecord", refField: "alltypesidrecordStringType"}}
             },
             keyFields: ["booleanType", "intType", "floatType", "decimalType", "stringType"],
-            joinMetadata: {
-                compositeassociationrecord: {entity: CompositeAssociationRecord, fieldName: "compositeassociationrecord", refTable: "CompositeAssociationRecord", refColumns: ["alltypesidrecordBooleanType", "alltypesidrecordIntType", "alltypesidrecordFloatType", "alltypesidrecordDecimalType", "alltypesidrecordStringType"], joinColumns: ["booleanType", "intType", "floatType", "decimalType", "stringType"], 'type: ONE_TO_ONE}
-            }
+            joinMetadata: {compositeAssociationRecord: {entity: CompositeAssociationRecord, fieldName: "compositeAssociationRecord", refTable: "CompositeAssociationRecord", refColumns: ["alltypesidrecordBooleanType", "alltypesidrecordIntType", "alltypesidrecordFloatType", "alltypesidrecordDecimalType", "alltypesidrecordStringType"], joinColumns: ["booleanType", "intType", "floatType", "decimalType", "stringType"], 'type: ONE_TO_ONE}}
         }
     };
 
@@ -217,8 +213,7 @@ public client class TestEntitiesClient {
 
     isolated resource function get intidrecord/[int id](IntIdRecordTargetType targetType = <>) returns targetType|Error = @java:Method {
         'class: "io.ballerina.stdlib.persist.QueryProcessor",
-        name: "queryOne",
-        paramTypes: ["io.ballerina.runtime.api.Environment", "io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "io.ballerina.runtime.api.values.BTypedesc"]
+        name: "queryOne"
     } external;
 
     isolated resource function post intidrecord(IntIdRecordInsert[] data) returns int[]|Error {
@@ -245,8 +240,7 @@ public client class TestEntitiesClient {
 
     isolated resource function get floatidrecord/[float id](FloatIdRecordTargetType targetType = <>) returns targetType|Error = @java:Method {
         'class: "io.ballerina.stdlib.persist.QueryProcessor",
-        name: "queryOne",
-        paramTypes: ["io.ballerina.runtime.api.Environment", "io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "io.ballerina.runtime.api.values.BTypedesc"]
+        name: "queryOne"
     } external;
 
     isolated resource function post floatidrecord(FloatIdRecordInsert[] data) returns float[]|Error {
@@ -329,8 +323,7 @@ public client class TestEntitiesClient {
 
     isolated resource function get compositeassociationrecord/[string id](CompositeAssociationRecordTargetType targetType = <>) returns targetType|Error = @java:Method {
         'class: "io.ballerina.stdlib.persist.QueryProcessor",
-        name: "queryOne",
-        paramTypes: ["io.ballerina.runtime.api.Environment", "io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "io.ballerina.runtime.api.values.BTypedesc"]
+        name: "queryOne"
     } external;
 
     isolated resource function post compositeassociationrecord(CompositeAssociationRecordInsert[] data) returns string[]|Error {
@@ -357,8 +350,7 @@ public client class TestEntitiesClient {
 
     isolated resource function get alltypesidrecord/[float floatType]/[decimal decimalType]/[boolean booleanType]/[int intType]/[string stringType](AllTypesIdRecordTargetType targetType = <>) returns targetType|Error = @java:Method {
         'class: "io.ballerina.stdlib.persist.QueryProcessor",
-        name: "queryOne",
-        paramTypes: ["io.ballerina.runtime.api.Environment", "io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "io.ballerina.runtime.api.values.BTypedesc"]
+        name: "queryOne"
     } external;
 
     isolated resource function post alltypesidrecord(AllTypesIdRecordInsert[] data) returns [boolean, int, float, decimal, string][]|Error {

--- a/ballerina/tests/test_entities_generated_client.bal
+++ b/ballerina/tests/test_entities_generated_client.bal
@@ -98,7 +98,13 @@ public client class TestEntitiesClient {
                 alltypesidrecordIntType: {columnName: "alltypesidrecordIntType"},
                 alltypesidrecordFloatType: {columnName: "alltypesidrecordFloatType"},
                 alltypesidrecordDecimalType: {columnName: "alltypesidrecordDecimalType"},
-                alltypesidrecordStringType: {columnName: "alltypesidrecordStringType"}
+                alltypesidrecordStringType: {columnName: "alltypesidrecordStringType"},
+                "alltypesidrecord.booleanType": {relation: {entityName: "alltypesidrecord", refField: "booleanType"}},
+                "alltypesidrecord.intType": {relation: {entityName: "alltypesidrecord", refField: "intType"}},
+                "alltypesidrecord.floatType": {relation: {entityName: "alltypesidrecord", refField: "floatType"}},
+                "alltypesidrecord.decimalType": {relation: {entityName: "alltypesidrecord", refField: "decimalType"}},
+                "alltypesidrecord.stringType": {relation: {entityName: "alltypesidrecord", refField: "stringType"}},
+                "alltypesidrecord.randomField": {relation: {entityName: "alltypesidrecord", refField: "randomField"}}
             },
             keyFields: ["id"],
             joinMetadata: {
@@ -114,7 +120,14 @@ public client class TestEntitiesClient {
                 floatType: {columnName: "floatType"},
                 decimalType: {columnName: "decimalType"},
                 stringType: {columnName: "stringType"},
-                randomField: {columnName: "randomField"}
+                randomField: {columnName: "randomField"},
+                "compositeassociationrecord.id": {relation: {entityName: "compositeassociationrecord", refField: "id"}},
+                "compositeassociationrecord.randomField": {relation: {entityName: "compositeassociationrecord", refField: "randomField"}},
+                "compositeassociationrecord.alltypesidrecordBooleanType": {relation: {entityName: "compositeassociationrecord", refField: "alltypesidrecordBooleanType"}},
+                "compositeassociationrecord.alltypesidrecordIntType": {relation: {entityName: "compositeassociationrecord", refField: "alltypesidrecordIntType"}},
+                "compositeassociationrecord.alltypesidrecordFloatType": {relation: {entityName: "compositeassociationrecord", refField: "alltypesidrecordFloatType"}},
+                "compositeassociationrecord.alltypesidrecordDecimalType": {relation: {entityName: "compositeassociationrecord", refField: "alltypesidrecordDecimalType"}},
+                "compositeassociationrecord.alltypesidrecordStringType": {relation: {entityName: "compositeassociationrecord", refField: "alltypesidrecordStringType"}}
             },
             keyFields: ["booleanType", "intType", "floatType", "decimalType", "stringType"],
             joinMetadata: {

--- a/ballerina/tests/test_entities_generated_types.bal
+++ b/ballerina/tests/test_entities_generated_types.bal
@@ -78,7 +78,7 @@ public type StringIdRecordUpdate record {|
 |};
 
 public type StringIdRecordOptionalized record {|
-    readonly string id?;
+    readonly string id;
     string randomField?;
 |};
 

--- a/ballerina/tests/test_entities_generated_types.bal
+++ b/ballerina/tests/test_entities_generated_types.bal
@@ -44,7 +44,7 @@ public type AllTypesUpdate record {|
 |};
 
 public type AllTypesOptionalized record {|
-    readonly int id?;
+    int id?;
     boolean booleanType?;
     int intType?;
     float floatType?;
@@ -78,7 +78,7 @@ public type StringIdRecordUpdate record {|
 |};
 
 public type StringIdRecordOptionalized record {|
-    readonly string id;
+    string id?;
     string randomField?;
 |};
 
@@ -96,7 +96,7 @@ public type IntIdRecordUpdate record {|
 |};
 
 public type IntIdRecordOptionalized record {|
-    readonly int id?;
+    int id?;
     string randomField?;
 |};
 
@@ -114,7 +114,7 @@ public type FloatIdRecordUpdate record {|
 |};
 
 public type FloatIdRecordOptionalized record {|
-    readonly float id?;
+    float id?;
     string randomField?;
 |};
 
@@ -132,7 +132,7 @@ public type DecimalIdRecordUpdate record {|
 |};
 
 public type DecimalIdRecordOptionalized record {|
-    readonly decimal id?;
+    decimal id?;
     string randomField?;
 |};
 
@@ -150,7 +150,7 @@ public type BooleanIdRecordUpdate record {|
 |};
 
 public type BooleanIdRecordOptionalized record {|
-    readonly boolean id?;
+    boolean id?;
     string randomField?;
 |};
 
@@ -178,7 +178,7 @@ public type CompositeAssociationRecordUpdate record {|
 |};
 
 public type CompositeAssociationRecordOptionalized record {|
-    readonly string id?;
+    string id?;
     string randomField?;
     boolean alltypesidrecordBooleanType?;
     int alltypesidrecordIntType?;
@@ -189,7 +189,7 @@ public type CompositeAssociationRecordOptionalized record {|
 
 public type CompositeAssociationRecordWithRelations record {|
     *CompositeAssociationRecordOptionalized;
-    AllTypesIdRecord alltypesidrecord?;
+    AllTypesIdRecordOptionalized alltypesidrecord?;
 |};
 
 public type CompositeAssociationRecordTargetType typedesc<CompositeAssociationRecordWithRelations>;
@@ -210,17 +210,17 @@ public type AllTypesIdRecordUpdate record {|
 |};
 
 public type AllTypesIdRecordOptionalized record {|
-    readonly boolean booleanType?;
-    readonly int intType?;
-    readonly float floatType?;
-    readonly decimal decimalType?;
-    readonly string stringType?;
+    boolean booleanType?;
+    int intType?;
+    float floatType?;
+    decimal decimalType?;
+    string stringType?;
     string randomField?;
 |};
 
 public type AllTypesIdRecordWithRelations record {|
     *AllTypesIdRecordOptionalized;
-    CompositeAssociationRecord compositeassociationrecord?;
+    CompositeAssociationRecordOptionalized compositeassociationrecord?;
 |};
 
 public type AllTypesIdRecordTargetType typedesc<AllTypesIdRecordWithRelations>;

--- a/ballerina/tests/test_entities_generated_types.bal
+++ b/ballerina/tests/test_entities_generated_types.bal
@@ -21,28 +21,6 @@ public type AllTypes record {|
     time:Civil? civilTypeOptional;
 |};
 
-public type AllTypesInsert AllTypes;
-
-public type AllTypesUpdate record {|
-    boolean booleanType?;
-    int intType?;
-    float floatType?;
-    decimal decimalType?;
-    string stringType?;
-    byte[] byteArrayType?;
-    time:Date dateType?;
-    time:TimeOfDay timeOfDayType?;
-    time:Civil civilType?;
-    boolean? booleanTypeOptional?;
-    int? intTypeOptional?;
-    float? floatTypeOptional?;
-    decimal? decimalTypeOptional?;
-    string? stringTypeOptional?;
-    time:Date? dateTypeOptional?;
-    time:TimeOfDay? timeOfDayTypeOptional?;
-    time:Civil? civilTypeOptional?;
-|};
-
 public type AllTypesOptionalized record {|
     int id?;
     boolean booleanType?;
@@ -66,15 +44,31 @@ public type AllTypesOptionalized record {|
 
 public type AllTypesTargetType typedesc<AllTypesOptionalized>;
 
+public type AllTypesInsert AllTypes;
+
+public type AllTypesUpdate record {|
+    boolean booleanType?;
+    int intType?;
+    float floatType?;
+    decimal decimalType?;
+    string stringType?;
+    byte[] byteArrayType?;
+    time:Date dateType?;
+    time:TimeOfDay timeOfDayType?;
+    time:Civil civilType?;
+    boolean? booleanTypeOptional?;
+    int? intTypeOptional?;
+    float? floatTypeOptional?;
+    decimal? decimalTypeOptional?;
+    string? stringTypeOptional?;
+    time:Date? dateTypeOptional?;
+    time:TimeOfDay? timeOfDayTypeOptional?;
+    time:Civil? civilTypeOptional?;
+|};
+
 public type StringIdRecord record {|
     readonly string id;
     string randomField;
-|};
-
-public type StringIdRecordInsert StringIdRecord;
-
-public type StringIdRecordUpdate record {|
-    string randomField?;
 |};
 
 public type StringIdRecordOptionalized record {|
@@ -84,15 +78,15 @@ public type StringIdRecordOptionalized record {|
 
 public type StringIdRecordTargetType typedesc<StringIdRecordOptionalized>;
 
+public type StringIdRecordInsert StringIdRecord;
+
+public type StringIdRecordUpdate record {|
+    string randomField?;
+|};
+
 public type IntIdRecord record {|
     readonly int id;
     string randomField;
-|};
-
-public type IntIdRecordInsert IntIdRecord;
-
-public type IntIdRecordUpdate record {|
-    string randomField?;
 |};
 
 public type IntIdRecordOptionalized record {|
@@ -102,15 +96,15 @@ public type IntIdRecordOptionalized record {|
 
 public type IntIdRecordTargetType typedesc<IntIdRecordOptionalized>;
 
+public type IntIdRecordInsert IntIdRecord;
+
+public type IntIdRecordUpdate record {|
+    string randomField?;
+|};
+
 public type FloatIdRecord record {|
     readonly float id;
     string randomField;
-|};
-
-public type FloatIdRecordInsert FloatIdRecord;
-
-public type FloatIdRecordUpdate record {|
-    string randomField?;
 |};
 
 public type FloatIdRecordOptionalized record {|
@@ -120,15 +114,15 @@ public type FloatIdRecordOptionalized record {|
 
 public type FloatIdRecordTargetType typedesc<FloatIdRecordOptionalized>;
 
+public type FloatIdRecordInsert FloatIdRecord;
+
+public type FloatIdRecordUpdate record {|
+    string randomField?;
+|};
+
 public type DecimalIdRecord record {|
     readonly decimal id;
     string randomField;
-|};
-
-public type DecimalIdRecordInsert DecimalIdRecord;
-
-public type DecimalIdRecordUpdate record {|
-    string randomField?;
 |};
 
 public type DecimalIdRecordOptionalized record {|
@@ -138,15 +132,15 @@ public type DecimalIdRecordOptionalized record {|
 
 public type DecimalIdRecordTargetType typedesc<DecimalIdRecordOptionalized>;
 
+public type DecimalIdRecordInsert DecimalIdRecord;
+
+public type DecimalIdRecordUpdate record {|
+    string randomField?;
+|};
+
 public type BooleanIdRecord record {|
     readonly boolean id;
     string randomField;
-|};
-
-public type BooleanIdRecordInsert BooleanIdRecord;
-
-public type BooleanIdRecordUpdate record {|
-    string randomField?;
 |};
 
 public type BooleanIdRecordOptionalized record {|
@@ -156,6 +150,12 @@ public type BooleanIdRecordOptionalized record {|
 
 public type BooleanIdRecordTargetType typedesc<BooleanIdRecordOptionalized>;
 
+public type BooleanIdRecordInsert BooleanIdRecord;
+
+public type BooleanIdRecordUpdate record {|
+    string randomField?;
+|};
+
 public type CompositeAssociationRecord record {|
     readonly string id;
     string randomField;
@@ -164,17 +164,6 @@ public type CompositeAssociationRecord record {|
     float alltypesidrecordFloatType;
     decimal alltypesidrecordDecimalType;
     string alltypesidrecordStringType;
-|};
-
-public type CompositeAssociationRecordInsert CompositeAssociationRecord;
-
-public type CompositeAssociationRecordUpdate record {|
-    string randomField?;
-    boolean alltypesidrecordBooleanType?;
-    int alltypesidrecordIntType?;
-    float alltypesidrecordFloatType?;
-    decimal alltypesidrecordDecimalType?;
-    string alltypesidrecordStringType?;
 |};
 
 public type CompositeAssociationRecordOptionalized record {|
@@ -189,10 +178,21 @@ public type CompositeAssociationRecordOptionalized record {|
 
 public type CompositeAssociationRecordWithRelations record {|
     *CompositeAssociationRecordOptionalized;
-    AllTypesIdRecordOptionalized alltypesidrecord?;
+    AllTypesIdRecordOptionalized allTypesIdRecord?;
 |};
 
 public type CompositeAssociationRecordTargetType typedesc<CompositeAssociationRecordWithRelations>;
+
+public type CompositeAssociationRecordInsert CompositeAssociationRecord;
+
+public type CompositeAssociationRecordUpdate record {|
+    string randomField?;
+    boolean alltypesidrecordBooleanType?;
+    int alltypesidrecordIntType?;
+    float alltypesidrecordFloatType?;
+    decimal alltypesidrecordDecimalType?;
+    string alltypesidrecordStringType?;
+|};
 
 public type AllTypesIdRecord record {|
     readonly boolean booleanType;
@@ -201,12 +201,6 @@ public type AllTypesIdRecord record {|
     readonly decimal decimalType;
     readonly string stringType;
     string randomField;
-|};
-
-public type AllTypesIdRecordInsert AllTypesIdRecord;
-
-public type AllTypesIdRecordUpdate record {|
-    string randomField?;
 |};
 
 public type AllTypesIdRecordOptionalized record {|
@@ -220,7 +214,13 @@ public type AllTypesIdRecordOptionalized record {|
 
 public type AllTypesIdRecordWithRelations record {|
     *AllTypesIdRecordOptionalized;
-    CompositeAssociationRecordOptionalized compositeassociationrecord?;
+    CompositeAssociationRecordOptionalized compositeAssociationRecord?;
 |};
 
 public type AllTypesIdRecordTargetType typedesc<AllTypesIdRecordWithRelations>;
+
+public type AllTypesIdRecordInsert AllTypesIdRecord;
+
+public type AllTypesIdRecordUpdate record {|
+    string randomField?;
+|};

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -17,49 +17,55 @@ import ballerina/sql;
 
 public class PersistStream {
     
-    private stream<anydata, sql:Error?>? anydataStream;
+    private stream<record {}, sql:Error?>? anydataStream;
     private Error? err;
-    private string[]? fields;
-    private string[]? include;
-    private typedesc<record{}>[]? typeDescriptions = ();
+    private string[] fields;
+    private string[] include;
+    private typedesc<record{}>[] typeDescriptions;
     private SQLClient? persistClient;
+    private typedesc<record {}> targetType;
 
-    public isolated function init(stream<anydata, sql:Error?>? anydataStream, Error? err = (), string[]? fields = (), string[]? include = (), any[]? typeDescriptions = (), SQLClient? persistClient = ()) {
+    public isolated function init(stream<record {}, sql:Error?>? anydataStream, typedesc<record {}> targetType, string[] fields, string[] include, any[] typeDescriptions, SQLClient persistClient, Error? err = ()) {
         self.anydataStream = anydataStream;
-        self.err = err;
         self.fields = fields;
         self.include = include;
+        self.targetType = targetType;
 
-        if typeDescriptions is any[] {
-            typedesc<record{}>[] typeDescriptionsArray = [];
-            foreach any typeDescription in typeDescriptions {
-                typeDescriptionsArray.push(<typedesc<record {}>>typeDescription);
-            }
-            self.typeDescriptions = typeDescriptionsArray;
-        } 
-        
+        typedesc<record{}>[] typeDescriptionsArray = [];
+        foreach any typeDescription in typeDescriptions {
+            typeDescriptionsArray.push(<typedesc<record {}>>typeDescription);
+        }
+        self.typeDescriptions = typeDescriptionsArray;
+    
         self.persistClient = persistClient;
+        self.err = err;
     }
 
-    public isolated function next() returns record {|anydata value;|}|Error? {
+    public isolated function next() returns record {|record {} value;|}|Error? {
         if self.err is Error {
             return <Error>self.err;
-        } else if self.anydataStream is stream<anydata, sql:Error?> {
-            var anydataStream = <stream<anydata, sql:Error?>>self.anydataStream;
+        } else if self.anydataStream is stream<record {}, sql:Error?> {
+            var anydataStream = <stream<record {}, sql:Error?>>self.anydataStream;
             var streamValue = anydataStream.next();
             if streamValue is () {
                 return streamValue;
             } else if (streamValue is sql:Error) {
                 return <Error>error(streamValue.message());
             } else {
-                anydata|error value = streamValue.value;
+                record {}|error value = streamValue.value;
                 if value is error {
                     return <Error>error(value.message());
                 }
-                record {|anydata value;|} nextRecord = {value: value};
-                if self.include is string[] {
-                    check (<SQLClient>self.persistClient).getManyRelations(nextRecord.value, <string[]> self.fields, <string[]>self.include, <typedesc<record {}>[]>self.typeDescriptions);
+                check (<SQLClient>self.persistClient).getManyRelations(value, self.fields, self.include, self.typeDescriptions);
+
+                string[] keyFields = (<SQLClient>self.persistClient).getKeyFields();
+                foreach string keyField in keyFields {
+                    if self.fields.indexOf(keyField) is () {
+                        _ = value.remove(keyField);
+                    }
                 }
+                
+                record {|record {} value;|} nextRecord = {value: checkpanic value.cloneWithType(self.targetType)};
                 return nextRecord;
             }
         } else {

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -223,7 +223,7 @@ There are six types of derived entity types:
     public type Workspace record {|
         readonly string workspaceId;
         string workspaceType;
-        string buildingBuildingCode;
+        string locationBuildingCode;
     |};
     ```
     
@@ -238,7 +238,7 @@ There are six types of derived entity types:
     ```ballerina
     public type WorkspaceUpdate record {|
         string workspaceType?;
-        string buildingBuildingCode?;
+        string locationBuildingCode?;
     |};
     ```
    

--- a/native/src/main/java/io/ballerina/stdlib/persist/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/persist/Constants.java
@@ -18,10 +18,10 @@
 
 package io.ballerina.stdlib.persist;
 
+import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.values.BString;
 
 import static io.ballerina.runtime.api.utils.StringUtils.fromString;
-
 /**
  * Constants for Persist module.
  *
@@ -33,8 +33,13 @@ public final class Constants {
 
     public static final BString PERSIST_CLIENTS = fromString("persistClients");
     public static final String PERSIST_STREAM = "PersistStream";
+    public static final BString KEY_FIELDS = fromString("keyFields");
+    public static final String ERROR = "Error";
+
     public static final String RUN_READ_QUERY_METHOD = "runReadQuery";
     public static final String RUN_READ_BY_KEY_QUERY_METHOD = "runReadByKeyQuery";
+    public static final Module BALLERINA_ANNOTATIONS_MODULE = new Module("ballerina", "lang.annotations", "0.0.0");
+    public static final String DEFAULT_STREAM_CONSTRAINT_NAME = "$stream$anon$constraint$";
 
     /**
      * Constant related to the Ballerina time types.

--- a/native/src/main/java/io/ballerina/stdlib/persist/QueryProcessor.java
+++ b/native/src/main/java/io/ballerina/stdlib/persist/QueryProcessor.java
@@ -22,8 +22,10 @@ import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.types.ErrorType;
 import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.types.StreamType;
+import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BFuture;
@@ -32,11 +34,14 @@ import io.ballerina.runtime.api.values.BStream;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
 
+import static io.ballerina.stdlib.persist.Constants.ERROR;
+import static io.ballerina.stdlib.persist.Constants.KEY_FIELDS;
 import static io.ballerina.stdlib.persist.Utils.getEntity;
 import static io.ballerina.stdlib.persist.Utils.getFutureResult;
 import static io.ballerina.stdlib.persist.Utils.getKey;
 import static io.ballerina.stdlib.persist.Utils.getMetadata;
 import static io.ballerina.stdlib.persist.Utils.getPersistClient;
+import static io.ballerina.stdlib.persist.Utils.getRecordTypeWithKeyFields;
 
 /**
  * This class provides the query processing implementations for persistence.
@@ -48,36 +53,50 @@ public class QueryProcessor {
     private QueryProcessor() {
     }
 
-    public static BStream query(Environment env, BObject client, BTypedesc recordType) {
+    public static BStream query(Environment env, BObject client, BTypedesc targetType) {
         BString entity = getEntity(env);
         BObject persistClient = getPersistClient(client, entity);
+        BArray keyFields = (BArray) persistClient.get(KEY_FIELDS);
+        RecordType recordType = (RecordType) targetType.getDescribingType();
 
-        RecordType streamConstraint = (RecordType) TypeUtils.getReferredType(recordType.getDescribingType());
-        StreamType streamType = TypeCreator.createStreamType(streamConstraint, PredefinedTypes.TYPE_NULL);
+        RecordType recordTypeWithIdFields = getRecordTypeWithKeyFields(keyFields, recordType);
+        BTypedesc targetTypeWithIdFields = ValueCreator.createTypedescValue(recordTypeWithIdFields);
+        StreamType streamTypeWithIdFields = TypeCreator.createStreamType(recordTypeWithIdFields,
+                PredefinedTypes.TYPE_NULL);
 
-        BArray[] metadata = getMetadata((RecordType) recordType.getDescribingType());
+        BArray[] metadata = getMetadata(recordType);
         BArray fields = metadata[0];
         BArray includes = metadata[1];
         BArray typeDescriptions = metadata[2];
 
         BFuture future = env.getRuntime().invokeMethodAsyncSequentially(
                 persistClient, Constants.RUN_READ_QUERY_METHOD,
-                null, null, null, null, streamType,
-                recordType, true, fields, true, includes, true
+                null, null, null, null, streamTypeWithIdFields,
+                targetTypeWithIdFields, true, fields, true, includes, true
         );
 
         BStream sqlStream = (BStream) getFutureResult(future);
         BObject persistStream = ValueCreator.createObjectValue(ModuleUtils.getModule(),
-                Constants.PERSIST_STREAM, sqlStream, null, fields, includes, typeDescriptions, persistClient);
+                Constants.PERSIST_STREAM, sqlStream, targetType, fields, includes, typeDescriptions,
+                persistClient, null);
 
+        RecordType streamConstraint = (RecordType) TypeUtils.getReferredType(targetType.getDescribingType());
         return ValueCreator.createStreamValue(TypeCreator.createStreamType(streamConstraint,
                 PredefinedTypes.TYPE_NULL), persistStream);
     }
 
-    public static Object queryOne(Environment env, BObject client, BArray path, BTypedesc recordType) {
+    public static Object queryOne(Environment env, BObject client, BArray path, BTypedesc targetType) {
         BString entity = getEntity(env);
-        RecordType recordConstraint = (RecordType) TypeUtils.getReferredType(recordType.getDescribingType());
-        BArray[] metadata = getMetadata((RecordType) recordType.getDescribingType());
+        BObject persistClient = getPersistClient(client, entity);
+        BArray keyFields = (BArray) persistClient.get(KEY_FIELDS);
+        RecordType recordType = (RecordType) targetType.getDescribingType();
+
+        RecordType recordTypeWithIdFields = getRecordTypeWithKeyFields(keyFields, recordType);
+        BTypedesc targetTypeWithIdFields = ValueCreator.createTypedescValue(recordTypeWithIdFields);
+        ErrorType persistErrorType = TypeCreator.createErrorType(ERROR, ModuleUtils.getModule());
+        Type unionType = TypeCreator.createUnionType(recordTypeWithIdFields, persistErrorType);
+
+        BArray[] metadata = getMetadata(recordType);
         BArray fields = metadata[0];
         BArray includes = metadata[1];
         BArray typeDescriptions = metadata[2];
@@ -86,8 +105,8 @@ public class QueryProcessor {
 
         BFuture future = env.getRuntime().invokeMethodAsyncSequentially(
                 getPersistClient(client, entity), Constants.RUN_READ_BY_KEY_QUERY_METHOD,
-                null, null, null, null, recordConstraint,
-                recordType, true, key, true, fields, true, includes, true,
+                null, null, null, null, unionType,
+                targetType, true, targetTypeWithIdFields, true, key, true, fields, true, includes, true,
                 typeDescriptions, true
         );
 

--- a/native/src/main/java/io/ballerina/stdlib/persist/Utils.java
+++ b/native/src/main/java/io/ballerina/stdlib/persist/Utils.java
@@ -174,7 +174,7 @@ public class Utils {
         }
     }
 
-    static RecordType getRecordTypeWithKeyFields(BArray keyFields, RecordType recordType) {
+    public static RecordType getRecordTypeWithKeyFields(BArray keyFields, RecordType recordType) {
         Map<String, Field> fieldsMap = new HashMap<>();
         for (Field field : recordType.getFields().values()) {
             fieldsMap.put(field.getFieldName(), field);

--- a/native/src/main/java/io/ballerina/stdlib/persist/Utils.java
+++ b/native/src/main/java/io/ballerina/stdlib/persist/Utils.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.flags.TypeFlags;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.Parameter;
@@ -37,6 +38,7 @@ import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -68,7 +70,7 @@ public class Utils {
     static BArray[] getMetadata(RecordType recordType) {
         ArrayType stringArrayType = TypeCreator.createArrayType(PredefinedTypes.TYPE_STRING);
 
-        //TODO: use PREDEFINED TYPE.TYPE_TYPEDESC once NPE issue is resolved
+        //TODO: use PredefinedTypes.TYPE_TYPEDESC once NPE issue is resolved
         ArrayType typeDescriptionArrayType = TypeCreator.createArrayType(PredefinedTypes.TYPE_ANY);
         BArray fieldsArray = ValueCreator.createArrayValue(stringArrayType);
         BArray includeArray = ValueCreator.createArrayValue(stringArrayType);
@@ -172,4 +174,22 @@ public class Utils {
         }
     }
 
+    static RecordType getRecordTypeWithKeyFields(BArray keyFields, RecordType recordType) {
+        Map<String, Field> fieldsMap = new HashMap<>();
+        for (Field field : recordType.getFields().values()) {
+            fieldsMap.put(field.getFieldName(), field);
+        }
+        for (int i = 0; i < keyFields.size(); i++) {
+            String key = keyFields.get(i).toString();
+            if (!fieldsMap.containsKey(key)) {
+                fieldsMap.put(key, TypeCreator.createField(PredefinedTypes.TYPE_STRING, key, 0));
+            }
+        }
+
+        return TypeCreator.createRecordType(
+                Constants.DEFAULT_STREAM_CONSTRAINT_NAME, Constants.BALLERINA_ANNOTATIONS_MODULE, 1,
+                fieldsMap, null, true,
+                TypeFlags.asMask(TypeFlags.ANYDATA, TypeFlags.PURETYPE)
+        );
+    }
 }


### PR DESCRIPTION
## Purpose
$subject

Related issue: https://github.com/ballerina-platform/ballerina-standard-library/issues/4087

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [x] Added tests
- [ ] Checked native-image compatibility
