### PR TITLE
Rename relation annotation refs field to keys

### DIFF
--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/Constants.java
@@ -32,7 +32,7 @@ public final class Constants {
     public static final String ARRAY = "[]";
     public static final String LS = System.lineSeparator();
     public static final String SQL_RELATION_MAPPING_ANNOTATION_NAME = "sql:Relation";
-    public static final String ANNOTATION_REFS_FIELD = "refs";
+    public static final String ANNOTATION_KEYS_FIELD = "keys";
 
     private Constants() {
     }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/PersistModelDefinitionValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/persist/compiler/PersistModelDefinitionValidator.java
@@ -65,7 +65,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static io.ballerina.stdlib.persist.compiler.Constants.ANNOTATION_REFS_FIELD;
+import static io.ballerina.stdlib.persist.compiler.Constants.ANNOTATION_KEYS_FIELD;
 import static io.ballerina.stdlib.persist.compiler.Constants.BallerinaTypes.BOOLEAN;
 import static io.ballerina.stdlib.persist.compiler.Constants.BallerinaTypes.DECIMAL;
 import static io.ballerina.stdlib.persist.compiler.Constants.BallerinaTypes.FLOAT;
@@ -845,7 +845,7 @@ public class PersistModelDefinitionValidator implements AnalysisTask<SyntaxNodeA
                                             RelationField ownerRelationField) {
         List<String> references = readStringArrayValueFromAnnotation
                 (ownerRelationField.getAnnotations(), Constants.SQL_RELATION_MAPPING_ANNOTATION_NAME,
-                        ANNOTATION_REFS_FIELD);
+                        ANNOTATION_KEYS_FIELD);
         if (references == null || !references.contains(field.getName())) {
             reportDiagnosticsEntity.reportDiagnostic(PERSIST_422.getCode(), MessageFormat.format(
                             PERSIST_422.getMessage(), foreignKey, referredEntity.getEntityName()),


### PR DESCRIPTION
## Purpose
This is part of the fix for the below task.
Fixes:
- [#6180](https://github.com/ballerina-platform/ballerina-library/issues/6180) 


## Checklist
- [X] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
